### PR TITLE
新增: Markdown 上傳預覽工具

### DIFF
--- a/.github/scripts/update_toc.py
+++ b/.github/scripts/update_toc.py
@@ -17,6 +17,7 @@ TOOL_CATEGORIES = {
     'text-diff-tool.html': 'text',
     'highlight_replace.html': 'text',
     'email.html': 'text',
+    'word-replace.html': 'text',
 
     # 圖片工具
     'pdf-to-png.html': 'image',
@@ -43,6 +44,7 @@ TOOL_ICONS = {
     'text-diff-tool.html': '🔍',
     'highlight_replace.html': '🖍️',
     'email.html': '📧',
+    'word-replace.html': '📃',
     'pdf-to-png.html': '📄',
     'resize-image.html': '📐',
     'card.html': '✂️',
@@ -65,6 +67,7 @@ TOOL_KEYWORDS = {
     'text-diff-tool.html': '差異 比對 diff 比較 文字',
     'highlight_replace.html': '取代 替換 replace 識別 highlight',
     'email.html': '信箱 email 郵件 暱稱 提取 extract',
+    'word-replace.html': 'word docx 批次 取代 替換 文件 office replace batch',
     'pdf-to-png.html': 'pdf png 轉換 圖片 convert',
     'resize-image.html': '縮小 圖片 resize 調整 尺寸 壓縮',
     'card.html': '裁剪 圖片 空白 水印 crop trim',

--- a/.github/scripts/update_toc.py
+++ b/.github/scripts/update_toc.py
@@ -31,6 +31,7 @@ TOOL_CATEGORIES = {
     'windows-to-wsl.html': 'dev',
     'iso-diff-tool.html': 'dev',
     'gsheet-to-markdown.html': 'dev',
+    'markdown-viewer.html': 'dev',
 }
 
 # 工具圖示設定
@@ -52,6 +53,7 @@ TOOL_ICONS = {
     'windows-to-wsl.html': '🪟',
     'iso-diff-tool.html': '📋',
     'gsheet-to-markdown.html': '📊',
+    'markdown-viewer.html': '📖',
 }
 
 # 工具關鍵字 (用於搜尋)
@@ -73,6 +75,7 @@ TOOL_KEYWORDS = {
     'windows-to-wsl.html': 'windows wsl linux 路徑 轉換 path',
     'iso-diff-tool.html': 'iso 差異 比對 文件 版本',
     'gsheet-to-markdown.html': 'google sheet markdown 表格 試算表 excel spreadsheet 轉換',
+    'markdown-viewer.html': 'markdown 預覽 上傳 檢視 viewer preview md gfm',
 }
 
 

--- a/index.html
+++ b/index.html
@@ -247,6 +247,17 @@
                             <svg class="w-5 h-5 text-gray-400 group-hover:text-blue-500 group-hover:translate-x-1 transition-all flex-shrink-0 mt-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
                         </div>
                     </a>
+
+                    <a href="word-replace.html" class="tool-card group block p-4 bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 hover:border-blue-500 dark:hover:border-blue-400 hover:shadow-lg hover:shadow-blue-500/10 transition-all touch-target" data-keywords="word docx 批次 取代 替換 文件 office replace batch">
+                        <div class="flex items-start gap-3">
+                            <span class="text-3xl flex-shrink-0" aria-hidden="true">📃</span>
+                            <div class="flex-1 min-w-0">
+                                <h3 class="font-semibold text-gray-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">Word 批次取代工具</h3>
+                                <p class="text-sm text-gray-500 dark:text-gray-400 mt-1 line-clamp-2">線上工具</p>
+                            </div>
+                            <svg class="w-5 h-5 text-gray-400 group-hover:text-blue-500 group-hover:translate-x-1 transition-all flex-shrink-0 mt-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+                        </div>
+                    </a>
 <!--TEXT_TOOLS_END-->
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -369,6 +369,17 @@
                         </div>
                     </a>
 
+                    <a href="markdown-viewer.html" class="tool-card group block p-4 bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 hover:border-blue-500 dark:hover:border-blue-400 hover:shadow-lg hover:shadow-blue-500/10 transition-all touch-target" data-keywords="markdown 預覽 上傳 檢視 viewer preview md gfm">
+                        <div class="flex items-start gap-3">
+                            <span class="text-3xl flex-shrink-0" aria-hidden="true">📖</span>
+                            <div class="flex-1 min-w-0">
+                                <h3 class="font-semibold text-gray-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">Markdown 上傳預覽工具</h3>
+                                <p class="text-sm text-gray-500 dark:text-gray-400 mt-1 line-clamp-2">免費線上 Markdown 上傳預覽工具，支援 .md 檔案上傳、拖放、直接貼上，即時渲染顯示...</p>
+                            </div>
+                            <svg class="w-5 h-5 text-gray-400 group-hover:text-blue-500 group-hover:translate-x-1 transition-all flex-shrink-0 mt-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+                        </div>
+                    </a>
+
                     <a href="windows-to-wsl.html" class="tool-card group block p-4 bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 hover:border-blue-500 dark:hover:border-blue-400 hover:shadow-lg hover:shadow-blue-500/10 transition-all touch-target" data-keywords="windows wsl linux 路徑 轉換 path">
                         <div class="flex items-start gap-3">
                             <span class="text-3xl flex-shrink-0" aria-hidden="true">🪟</span>

--- a/markdown-viewer.html
+++ b/markdown-viewer.html
@@ -1,0 +1,467 @@
+<!DOCTYPE html>
+<html lang="zh-TW" class="scroll-smooth">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <!-- SEO -->
+    <title>Markdown 上傳預覽工具 - 線上 Markdown 檢視器 | FeiFei Tools</title>
+    <meta name="description" content="免費線上 Markdown 上傳預覽工具，支援 .md 檔案上傳、拖放、直接貼上，即時渲染顯示為網頁，支援 GFM、程式碼高亮、深色模式。">
+    <meta name="keywords" content="Markdown預覽,Markdown上傳,Markdown檢視器,md viewer,markdown preview,線上工具">
+    <meta name="author" content="FeiFei">
+    <link rel="canonical" href="https://tool.feifei.tw/markdown-viewer.html">
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://tool.feifei.tw/markdown-viewer.html">
+    <meta property="og:title" content="Markdown 上傳預覽工具 | FeiFei Tools">
+    <meta property="og:description" content="上傳 Markdown 檔案，即時渲染顯示為網頁，支援 GFM 表格、程式碼高亮。">
+    <meta property="og:image" content="https://tool.feifei.tw/og-image.png">
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Markdown 上傳預覽工具 | FeiFei Tools">
+    <meta name="twitter:description" content="上傳 Markdown 檔案，即時渲染顯示為網頁。">
+
+    <!-- GA -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-B20B804DQS"></script>
+    <script>window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-B20B804DQS');</script>
+
+    <!-- 防止主題閃爍 -->
+    <script>(function() { const saved = localStorage.getItem('theme'); const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches; if (saved === 'dark' || (!saved && prefersDark)) { document.documentElement.classList.add('dark'); } })();</script>
+
+    <!-- Tailwind + Typography -->
+    <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+    <script>tailwind.config = { darkMode: 'class', theme: { extend: { fontFamily: { sans: ['Noto Sans TC', 'system-ui', 'sans-serif'] } } } }</script>
+
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;700&display=swap" rel="stylesheet">
+
+    <!-- marked.js (Markdown Parser) -->
+    <script src="https://cdn.jsdelivr.net/npm/marked@12.0.2/marked.min.js"></script>
+    <!-- DOMPurify (XSS Sanitizer) -->
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.11/dist/purify.min.js"></script>
+    <!-- highlight.js (Code Highlight) -->
+    <link id="hljs-theme-light" rel="stylesheet" href="https://cdn.jsdelivr.net/npm/highlight.js@11.9.0/styles/github.min.css">
+    <link id="hljs-theme-dark" rel="stylesheet" href="https://cdn.jsdelivr.net/npm/highlight.js@11.9.0/styles/github-dark.min.css" disabled>
+    <script src="https://cdn.jsdelivr.net/npm/highlight.js@11.9.0/lib/common.min.js"></script>
+
+    <!-- JSON-LD -->
+    <script type="application/ld+json">{ "@context": "https://schema.org", "@type": "WebApplication", "name": "Markdown 上傳預覽工具", "url": "https://tool.feifei.tw/markdown-viewer.html", "description": "Markdown 檔案上傳與線上預覽工具", "applicationCategory": "UtilityApplication", "operatingSystem": "Any", "offers": { "@type": "Offer", "price": "0", "priceCurrency": "TWD" } }</script>
+
+    <style>
+        .touch-target { min-height: 44px; min-width: 44px; }
+        .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }
+        .dropzone.is-dragover { border-color: rgb(37 99 235); background-color: rgb(239 246 255); }
+        .dark .dropzone.is-dragover { border-color: rgb(96 165 250); background-color: rgba(30 58 138 / 0.3); }
+        /* 渲染區的程式碼區塊微調 */
+        .markdown-output pre { padding: 0; background: transparent; }
+        .markdown-output pre code.hljs { border-radius: 0.75rem; padding: 1rem; font-size: 0.875rem; }
+        .markdown-output :not(pre) > code {
+            background-color: rgb(243 244 246);
+            color: rgb(190 24 93);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.375rem;
+            font-size: 0.875em;
+        }
+        .dark .markdown-output :not(pre) > code {
+            background-color: rgb(55 65 81);
+            color: rgb(244 114 182);
+        }
+        .markdown-output table { display: table; width: 100%; }
+        .markdown-output img { max-width: 100%; height: auto; border-radius: 0.5rem; }
+        .markdown-output blockquote { border-left-color: rgb(59 130 246); }
+    </style>
+</head>
+<body class="font-sans bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 antialiased">
+
+    <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 bg-blue-600 text-white px-4 py-2 rounded-lg z-[100]">跳至主要內容</a>
+
+    <!-- Desktop Header -->
+    <header class="hidden md:block sticky top-0 z-40 bg-white/80 dark:bg-gray-800/80 backdrop-blur-lg border-b border-gray-200 dark:border-gray-700">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex items-center justify-between h-16">
+                <a href="index.html" class="flex items-center gap-2 touch-target"><span class="text-2xl">🛠️</span><span class="font-bold text-xl">FeiFei Tools</span></a>
+                <nav class="flex items-center gap-1"><a href="index.html" class="px-3 py-2 rounded-lg text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 text-sm">首頁</a><span class="text-gray-300 dark:text-gray-600">/</span><span class="px-3 py-2 text-gray-900 dark:text-white font-medium text-sm">Markdown 預覽</span></nav>
+                <button id="theme-toggle-desktop" class="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors touch-target" aria-label="切換深色模式">
+                    <svg class="w-6 h-6 hidden dark:block text-yellow-400" fill="currentColor" viewBox="0 0 20 20"><path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+                    <svg class="w-6 h-6 block dark:hidden text-gray-600" fill="currentColor" viewBox="0 0 20 20"><path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/></svg>
+                </button>
+            </div>
+        </div>
+    </header>
+
+    <!-- Main -->
+    <main id="main-content" class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-6 md:py-8 pb-24 md:pb-8">
+        <div class="mb-6">
+            <h1 class="text-2xl md:text-3xl font-bold mb-2 flex items-center gap-3"><span class="text-3xl">📖</span>Markdown 上傳預覽工具</h1>
+            <p class="text-gray-600 dark:text-gray-400">上傳 .md 檔案或直接貼上 Markdown 內容，即時渲染顯示於網頁</p>
+        </div>
+
+        <div class="space-y-6">
+            <!-- Upload Dropzone -->
+            <section>
+                <label for="file-input" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">上傳 Markdown 檔案</label>
+                <div id="dropzone" class="dropzone relative flex flex-col items-center justify-center gap-2 p-8 border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-xl bg-white dark:bg-gray-800 hover:border-blue-500 dark:hover:border-blue-400 transition-colors cursor-pointer">
+                    <svg class="w-10 h-10 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"/></svg>
+                    <p class="text-sm text-gray-600 dark:text-gray-300 text-center">
+                        <span class="font-medium text-blue-600 dark:text-blue-400">點擊選擇檔案</span> 或拖曳檔案到此處
+                    </p>
+                    <p class="text-xs text-gray-500 dark:text-gray-400">支援 .md / .markdown / .txt 檔案</p>
+                    <input id="file-input" type="file" accept=".md,.markdown,.txt,text/markdown,text/plain" class="absolute inset-0 opacity-0 cursor-pointer" aria-label="選擇 Markdown 檔案">
+                </div>
+                <p id="file-info" class="text-xs text-gray-500 dark:text-gray-400 mt-2 hidden"></p>
+            </section>
+
+            <!-- Tabs -->
+            <div class="flex items-center gap-2 border-b border-gray-200 dark:border-gray-700">
+                <button id="tab-edit" class="tab-btn px-4 py-2 text-sm font-medium border-b-2 border-blue-600 text-blue-600 dark:text-blue-400 transition-colors touch-target" data-target="panel-edit">編輯</button>
+                <button id="tab-preview" class="tab-btn px-4 py-2 text-sm font-medium border-b-2 border-transparent text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 transition-colors touch-target" data-target="panel-preview">預覽</button>
+                <button id="tab-split" class="tab-btn hidden md:inline-flex px-4 py-2 text-sm font-medium border-b-2 border-transparent text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 transition-colors touch-target" data-target="panel-split">並排</button>
+                <div class="ml-auto flex items-center gap-3 pb-2">
+                    <label class="inline-flex items-center gap-2 cursor-pointer">
+                        <input id="auto-render" type="checkbox" checked class="w-4 h-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500">
+                        <span class="text-xs text-gray-700 dark:text-gray-300">即時渲染</span>
+                    </label>
+                </div>
+            </div>
+
+            <!-- Panels -->
+            <section>
+                <!-- Edit Panel -->
+                <div id="panel-edit" class="panel">
+                    <textarea id="markdown-input" class="w-full p-4 border border-gray-300 dark:border-gray-600 rounded-xl bg-white dark:bg-gray-800 focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-y min-h-[400px] font-mono text-sm" placeholder="在這裡貼上或編輯 Markdown 內容...&#10;&#10;# 範例標題&#10;&#10;這是一段 **粗體** 與 *斜體* 文字。&#10;&#10;- 項目一&#10;- 項目二&#10;&#10;```js&#10;console.log('Hello, Markdown!');&#10;```"></textarea>
+                </div>
+
+                <!-- Preview Panel -->
+                <div id="panel-preview" class="panel hidden">
+                    <article id="markdown-output" class="markdown-output prose prose-blue dark:prose-invert max-w-none p-6 border border-gray-200 dark:border-gray-700 rounded-xl bg-white dark:bg-gray-800 min-h-[400px]">
+                        <p class="text-gray-400 dark:text-gray-500">尚未有預覽內容...</p>
+                    </article>
+                </div>
+
+                <!-- Split Panel -->
+                <div id="panel-split" class="panel hidden grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <textarea id="markdown-input-split" class="w-full p-4 border border-gray-300 dark:border-gray-600 rounded-xl bg-white dark:bg-gray-800 focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-y min-h-[500px] font-mono text-sm" placeholder="在這裡輸入 Markdown..."></textarea>
+                    <article id="markdown-output-split" class="markdown-output prose prose-blue dark:prose-invert max-w-none p-6 border border-gray-200 dark:border-gray-700 rounded-xl bg-white dark:bg-gray-800 min-h-[500px] overflow-auto">
+                        <p class="text-gray-400 dark:text-gray-500">尚未有預覽內容...</p>
+                    </article>
+                </div>
+            </section>
+
+            <!-- Actions -->
+            <div class="flex flex-wrap gap-3">
+                <button id="btn-render" class="inline-flex items-center justify-center gap-2 px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-xl transition-colors touch-target">
+                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/></svg>
+                    立即渲染
+                </button>
+                <button id="btn-copy-html" class="inline-flex items-center justify-center gap-2 px-6 py-3 bg-green-600 hover:bg-green-700 text-white font-medium rounded-xl transition-colors touch-target">
+                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2"/></svg>
+                    複製 HTML
+                </button>
+                <button id="btn-download-html" class="inline-flex items-center justify-center gap-2 px-6 py-3 bg-purple-600 hover:bg-purple-700 text-white font-medium rounded-xl transition-colors touch-target">
+                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/></svg>
+                    下載 HTML
+                </button>
+                <button id="btn-load-sample" class="inline-flex items-center justify-center gap-2 px-6 py-3 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 font-medium rounded-xl transition-colors touch-target">載入範例</button>
+                <button id="btn-clear" class="inline-flex items-center justify-center gap-2 px-6 py-3 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 font-medium rounded-xl transition-colors touch-target">清除</button>
+            </div>
+
+            <!-- Info -->
+            <div class="bg-blue-50 dark:bg-blue-900/20 rounded-xl p-4 text-sm text-blue-800 dark:text-blue-200">
+                <p class="font-medium mb-1">使用說明</p>
+                <ul class="list-disc list-inside space-y-1 text-blue-700 dark:text-blue-300">
+                    <li>支援上傳 <code class="font-mono">.md</code>、<code class="font-mono">.markdown</code>、<code class="font-mono">.txt</code> 檔案，或直接拖曳到上方區域</li>
+                    <li>支援 GitHub Flavored Markdown（GFM）：表格、刪除線、任務清單、自動連結</li>
+                    <li>程式碼區塊自動套用語法高亮（highlight.js）</li>
+                    <li>內容已透過 DOMPurify 清理，安全防止 XSS</li>
+                    <li>檔案僅在瀏覽器本機處理，不會上傳到伺服器</li>
+                </ul>
+            </div>
+        </div>
+    </main>
+
+    <!-- Mobile Nav -->
+    <nav class="md:hidden fixed bottom-0 left-0 right-0 z-50 bg-white/90 dark:bg-gray-800/90 backdrop-blur-lg border-t border-gray-200 dark:border-gray-700" style="padding-bottom: env(safe-area-inset-bottom, 0);">
+        <div class="grid grid-cols-5 h-16">
+            <a href="index.html" class="flex flex-col items-center justify-center text-gray-600 dark:text-gray-400 touch-target"><svg class="w-6 h-6" fill="currentColor" viewBox="0 0 20 20"><path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z"/></svg><span class="text-xs mt-0.5">首頁</span></a>
+            <a href="index.html#text-tools" class="flex flex-col items-center justify-center text-gray-600 dark:text-gray-400 touch-target"><svg class="w-6 h-6" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4z" clip-rule="evenodd"/></svg><span class="text-xs mt-0.5">文字</span></a>
+            <a href="index.html#image-tools" class="flex flex-col items-center justify-center text-gray-600 dark:text-gray-400 touch-target"><svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg><span class="text-xs mt-0.5">圖片</span></a>
+            <a href="index.html#dev-tools" class="flex flex-col items-center justify-center text-blue-600 dark:text-blue-400 touch-target"><svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/></svg><span class="text-xs mt-0.5 font-medium">開發</span></a>
+            <button id="theme-toggle-mobile" class="flex flex-col items-center justify-center text-gray-600 dark:text-gray-400 touch-target"><svg class="w-6 h-6 hidden dark:block" fill="currentColor" viewBox="0 0 20 20"><path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0z"/></svg><svg class="w-6 h-6 block dark:hidden" fill="currentColor" viewBox="0 0 20 20"><path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/></svg><span class="text-xs mt-0.5">主題</span></button>
+        </div>
+    </nav>
+
+    <!-- Toast -->
+    <div id="toast" class="fixed bottom-24 md:bottom-8 left-1/2 -translate-x-1/2 bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 px-4 py-2 rounded-lg shadow-lg transform transition-all duration-300 opacity-0 translate-y-4 pointer-events-none z-[60]"><span id="toast-message"></span></div>
+
+    <script>
+        // ========== Theme ==========
+        function applyHljsTheme() {
+            const isDark = document.documentElement.classList.contains('dark');
+            document.getElementById('hljs-theme-light').disabled = isDark;
+            document.getElementById('hljs-theme-dark').disabled = !isDark;
+        }
+        function toggleTheme() {
+            const isDark = document.documentElement.classList.toggle('dark');
+            localStorage.setItem('theme', isDark ? 'dark' : 'light');
+            applyHljsTheme();
+        }
+        document.getElementById('theme-toggle-desktop')?.addEventListener('click', toggleTheme);
+        document.getElementById('theme-toggle-mobile')?.addEventListener('click', toggleTheme);
+        applyHljsTheme();
+
+        // ========== Toast ==========
+        function showToast(msg, duration = 2000) {
+            const toast = document.getElementById('toast');
+            document.getElementById('toast-message').textContent = msg;
+            toast.classList.remove('opacity-0', 'translate-y-4', 'pointer-events-none');
+            toast.classList.add('opacity-100', 'translate-y-0');
+            setTimeout(() => {
+                toast.classList.add('opacity-0', 'translate-y-4', 'pointer-events-none');
+                toast.classList.remove('opacity-100', 'translate-y-0');
+            }, duration);
+        }
+
+        // ========== Marked Setup ==========
+        marked.setOptions({
+            gfm: true,
+            breaks: true,
+            highlight: function(code, lang) {
+                try {
+                    if (lang && hljs.getLanguage(lang)) {
+                        return hljs.highlight(code, { language: lang }).value;
+                    }
+                    return hljs.highlightAuto(code).value;
+                } catch (e) {
+                    return code;
+                }
+            }
+        });
+
+        // ========== Elements ==========
+        const fileInput = document.getElementById('file-input');
+        const dropzone = document.getElementById('dropzone');
+        const fileInfo = document.getElementById('file-info');
+        const inputEdit = document.getElementById('markdown-input');
+        const inputSplit = document.getElementById('markdown-input-split');
+        const outputPreview = document.getElementById('markdown-output');
+        const outputSplit = document.getElementById('markdown-output-split');
+        const autoRender = document.getElementById('auto-render');
+
+        // ========== Render ==========
+        function renderMarkdown(source) {
+            if (!source || !source.trim()) {
+                const empty = '<p class="text-gray-400 dark:text-gray-500">尚未有預覽內容...</p>';
+                outputPreview.innerHTML = empty;
+                outputSplit.innerHTML = empty;
+                return;
+            }
+            const rawHtml = marked.parse(source);
+            const cleanHtml = DOMPurify.sanitize(rawHtml, {
+                ADD_ATTR: ['target', 'rel'],
+            });
+            outputPreview.innerHTML = cleanHtml;
+            outputSplit.innerHTML = cleanHtml;
+            // 確保連結在新分頁開啟
+            outputPreview.querySelectorAll('a[href^="http"]').forEach(a => { a.target = '_blank'; a.rel = 'noopener noreferrer'; });
+            outputSplit.querySelectorAll('a[href^="http"]').forEach(a => { a.target = '_blank'; a.rel = 'noopener noreferrer'; });
+        }
+
+        function syncAndRender(source) {
+            inputEdit.value = source;
+            inputSplit.value = source;
+            renderMarkdown(source);
+        }
+
+        inputEdit.addEventListener('input', () => {
+            inputSplit.value = inputEdit.value;
+            if (autoRender.checked) renderMarkdown(inputEdit.value);
+        });
+        inputSplit.addEventListener('input', () => {
+            inputEdit.value = inputSplit.value;
+            if (autoRender.checked) renderMarkdown(inputSplit.value);
+        });
+
+        // ========== File Upload ==========
+        function handleFile(file) {
+            if (!file) return;
+            const maxSize = 5 * 1024 * 1024; // 5MB
+            if (file.size > maxSize) { showToast('檔案過大（超過 5MB）'); return; }
+            const reader = new FileReader();
+            reader.onload = (e) => {
+                const text = e.target.result;
+                syncAndRender(text);
+                fileInfo.textContent = `已載入：${file.name}（${(file.size / 1024).toFixed(1)} KB）`;
+                fileInfo.classList.remove('hidden');
+                showToast('檔案已載入');
+                // 自動切到預覽
+                if (window.matchMedia('(max-width: 767px)').matches) switchTab('panel-preview');
+                else switchTab('panel-split');
+            };
+            reader.onerror = () => showToast('讀取檔案失敗');
+            reader.readAsText(file, 'UTF-8');
+        }
+
+        fileInput.addEventListener('change', (e) => handleFile(e.target.files[0]));
+
+        ['dragenter', 'dragover'].forEach(evt => {
+            dropzone.addEventListener(evt, (e) => { e.preventDefault(); e.stopPropagation(); dropzone.classList.add('is-dragover'); });
+        });
+        ['dragleave', 'drop'].forEach(evt => {
+            dropzone.addEventListener(evt, (e) => { e.preventDefault(); e.stopPropagation(); dropzone.classList.remove('is-dragover'); });
+        });
+        dropzone.addEventListener('drop', (e) => {
+            const file = e.dataTransfer.files[0];
+            handleFile(file);
+        });
+
+        // ========== Tabs ==========
+        const tabBtns = document.querySelectorAll('.tab-btn');
+        const panels = document.querySelectorAll('.panel');
+        function switchTab(targetId) {
+            tabBtns.forEach(btn => {
+                const active = btn.dataset.target === targetId;
+                btn.classList.toggle('border-blue-600', active);
+                btn.classList.toggle('text-blue-600', active);
+                btn.classList.toggle('dark:text-blue-400', active);
+                btn.classList.toggle('border-transparent', !active);
+                btn.classList.toggle('text-gray-600', !active);
+                btn.classList.toggle('dark:text-gray-400', !active);
+            });
+            panels.forEach(p => {
+                if (p.id === targetId) {
+                    p.classList.remove('hidden');
+                    if (p.id === 'panel-split') p.classList.add('grid');
+                } else {
+                    p.classList.add('hidden');
+                    if (p.id === 'panel-split') p.classList.remove('grid');
+                }
+            });
+            if (targetId !== 'panel-edit') renderMarkdown(inputEdit.value);
+        }
+        tabBtns.forEach(btn => btn.addEventListener('click', () => switchTab(btn.dataset.target)));
+
+        // ========== Buttons ==========
+        document.getElementById('btn-render').addEventListener('click', () => {
+            renderMarkdown(inputEdit.value);
+            switchTab('panel-preview');
+            showToast('已渲染');
+        });
+
+        document.getElementById('btn-copy-html').addEventListener('click', async () => {
+            const html = outputPreview.innerHTML;
+            if (!html || outputPreview.textContent.trim() === '尚未有預覽內容...') {
+                showToast('沒有內容可複製');
+                return;
+            }
+            try {
+                await navigator.clipboard.writeText(html);
+                showToast('HTML 已複製到剪貼簿');
+            } catch {
+                showToast('複製失敗');
+            }
+        });
+
+        document.getElementById('btn-download-html').addEventListener('click', () => {
+            const source = inputEdit.value;
+            if (!source.trim()) { showToast('沒有內容可下載'); return; }
+            const rendered = DOMPurify.sanitize(marked.parse(source));
+            const isDark = document.documentElement.classList.contains('dark');
+            const fullHtml = `<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+<meta charset="UTF-8">
+<title>Markdown Preview</title>
+<style>
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans TC", sans-serif; max-width: 820px; margin: 2rem auto; padding: 0 1rem; line-height: 1.7; color: #1f2937; }
+h1, h2, h3 { margin-top: 1.5em; }
+pre { background: #f3f4f6; padding: 1rem; border-radius: 0.5rem; overflow-x: auto; }
+code { background: #f3f4f6; padding: 0.125rem 0.375rem; border-radius: 0.25rem; font-size: 0.9em; }
+pre code { background: transparent; padding: 0; }
+blockquote { border-left: 4px solid #3b82f6; padding-left: 1rem; color: #4b5563; margin-left: 0; }
+table { border-collapse: collapse; width: 100%; }
+th, td { border: 1px solid #e5e7eb; padding: 0.5rem; }
+th { background: #f9fafb; }
+img { max-width: 100%; height: auto; }
+a { color: #2563eb; }
+</style>
+</head>
+<body>
+${rendered}
+</body>
+</html>`;
+            const blob = new Blob([fullHtml], { type: 'text/html;charset=utf-8' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = 'markdown-preview.html';
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+            showToast('HTML 已下載');
+        });
+
+        document.getElementById('btn-clear').addEventListener('click', () => {
+            inputEdit.value = '';
+            inputSplit.value = '';
+            renderMarkdown('');
+            fileInfo.classList.add('hidden');
+            fileInput.value = '';
+            showToast('已清除');
+        });
+
+        document.getElementById('btn-load-sample').addEventListener('click', () => {
+            const sample = `# Markdown 預覽範例
+
+> 這是一個 **Markdown 預覽工具**，支援 GitHub Flavored Markdown。
+
+## 功能特色
+
+- 上傳 \`.md\` 檔案或直接輸入
+- 即時渲染與並排顯示
+- 程式碼語法高亮
+- 表格、任務清單、刪除線
+
+### 任務清單
+
+- [x] 上傳檔案
+- [x] 即時渲染
+- [ ] 匯出 PDF（未來規劃）
+
+### 表格範例
+
+| 名稱 | 類型 | 說明 |
+| --- | --- | --- |
+| marked | Library | Markdown 解析器 |
+| DOMPurify | Library | XSS 防護 |
+| highlight.js | Library | 語法高亮 |
+
+### 程式碼
+
+\`\`\`javascript
+function greet(name) {
+  console.log(\`Hello, \${name}!\`);
+}
+greet('FeiFei Tools');
+\`\`\`
+
+### 連結與圖片
+
+[FeiFei Tools 官網](https://tool.feifei.tw/)
+
+---
+
+~~刪除線文字~~ 與 *斜體* 與 **粗體** 的組合。
+`;
+            syncAndRender(sample);
+            showToast('已載入範例');
+        });
+
+        // 初始渲染
+        renderMarkdown(inputEdit.value);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
支援上傳 .md/.markdown/.txt 檔案、拖放、直接貼上，
即時渲染為網頁，支援 GFM、程式碼語法高亮、深色模式，
並提供編輯/預覽/並排三種檢視模式與 HTML 下載/複製功能。

https://claude.ai/code/session_01Q4f4Ttx2QXYiNCvBs95QQM