### PR TITLE
新增 6 個工具 + 統一 Word 批次取代樣式

### DIFF
--- a/.github/scripts/update_toc.py
+++ b/.github/scripts/update_toc.py
@@ -21,9 +21,11 @@ TOOL_CATEGORIES = {
 
     # 圖片工具
     'pdf-to-png.html': 'image',
+    'pdf-to-txt.html': 'image',
     'resize-image.html': 'image',
     'card.html': 'image',
     'exif.html': 'image',
+    'image-to-base64.html': 'image',
 
     # 開發工具
     'bash.html': 'dev',
@@ -33,6 +35,10 @@ TOOL_CATEGORIES = {
     'iso-diff-tool.html': 'dev',
     'gsheet-to-markdown.html': 'dev',
     'markdown-viewer.html': 'dev',
+    'json-formatter.html': 'dev',
+    'url-encode.html': 'dev',
+    'jwt-decoder.html': 'dev',
+    'qr-generator.html': 'dev',
 }
 
 # 工具圖示設定
@@ -46,9 +52,11 @@ TOOL_ICONS = {
     'email.html': '📧',
     'word-replace.html': '📃',
     'pdf-to-png.html': '📄',
+    'pdf-to-txt.html': '📄',
     'resize-image.html': '📐',
     'card.html': '✂️',
     'exif.html': '📷',
+    'image-to-base64.html': '🖼️',
     'bash.html': '💻',
     'encry.html': '🔐',
     'html-to-markdown.html': '📝',
@@ -56,6 +64,10 @@ TOOL_ICONS = {
     'iso-diff-tool.html': '📋',
     'gsheet-to-markdown.html': '📊',
     'markdown-viewer.html': '📖',
+    'json-formatter.html': '{ }',
+    'url-encode.html': '🔗',
+    'jwt-decoder.html': '🔑',
+    'qr-generator.html': '▦',
 }
 
 # 工具關鍵字 (用於搜尋)
@@ -69,9 +81,11 @@ TOOL_KEYWORDS = {
     'email.html': '信箱 email 郵件 暱稱 提取 extract',
     'word-replace.html': 'word docx 批次 取代 替換 文件 office replace batch',
     'pdf-to-png.html': 'pdf png 轉換 圖片 convert',
+    'pdf-to-txt.html': 'pdf txt 純文字 擷取 抽取 文字 extract text',
     'resize-image.html': '縮小 圖片 resize 調整 尺寸 壓縮',
     'card.html': '裁剪 圖片 空白 水印 crop trim',
     'exif.html': 'exif 照片 資訊 相機 gps 元資料',
+    'image-to-base64.html': '圖片 base64 data url 編碼 image to base64 dataurl',
     'bash.html': '終端 指令 bash shell command terminal',
     'encry.html': '編碼 加密 解密 base64 md5 sha aes hash',
     'html-to-markdown.html': 'html markdown 轉換 convert md',
@@ -79,6 +93,10 @@ TOOL_KEYWORDS = {
     'iso-diff-tool.html': 'iso 差異 比對 文件 版本',
     'gsheet-to-markdown.html': 'google sheet markdown 表格 試算表 excel spreadsheet 轉換',
     'markdown-viewer.html': 'markdown 預覽 上傳 檢視 viewer preview md gfm',
+    'json-formatter.html': 'json 格式化 美化 壓縮 驗證 樹狀 formatter prettify minify validate',
+    'url-encode.html': 'url 編碼 解碼 encode decode encodeURIComponent 查詢字串 query string',
+    'jwt-decoder.html': 'jwt token 解碼 解析 jwt decoder 認證 auth',
+    'qr-generator.html': 'qr code 二維碼 產生器 generator png svg',
 }
 
 

--- a/README.md
+++ b/README.md
@@ -39,13 +39,18 @@
 | [PDF 轉 PNG](https://tool.feifei.tw/pdf-to-png.html) | 將 PDF 轉換為圖片 |
 | [PDF 轉 TXT](https://tool.feifei.tw/pdf-to-txt.html) | 擷取 PDF 純文字內容 |
 | [縮小圖片](https://tool.feifei.tw/resize-image.html) | 調整圖片尺寸大小 |
+| [圖片轉 Base64](https://tool.feifei.tw/image-to-base64.html) | 圖片轉 Data URL（PNG/JPEG/WebP） |
 | [裁剪圖片](https://tool.feifei.tw/card.html) | 自動裁剪空白和水印 |
 | [EXIF 讀取](https://tool.feifei.tw/exif.html) | 讀取照片 EXIF 資訊 |
+| [QR Code 產生器](https://tool.feifei.tw/qr-generator.html) | 產生 QR Code，下載 PNG / SVG |
 
 ### 開發者工具
 
 | 工具 | 說明 |
 |------|------|
+| [JSON 格式化](https://tool.feifei.tw/json-formatter.html) | JSON 美化、壓縮、驗證、樹狀檢視 |
+| [URL 編解碼](https://tool.feifei.tw/url-encode.html) | URL Encode / Decode 與查詢字串拆解 |
+| [JWT 解碼器](https://tool.feifei.tw/jwt-decoder.html) | JWT Token 解析 Header / Payload |
 | [終端指令提取](https://tool.feifei.tw/bash.html) | 從終端輸出中提取指令 |
 | [編碼/加解密](https://tool.feifei.tw/encry.html) | Base64、MD5、SHA、AES |
 | [HTML 轉 Markdown](https://tool.feifei.tw/html-to-markdown.html) | 將 HTML 轉換為 Markdown |

--- a/image-to-base64.html
+++ b/image-to-base64.html
@@ -1,0 +1,344 @@
+<!DOCTYPE html>
+<html lang="zh-TW" class="scroll-smooth">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <title>圖片轉 Base64 - 線上免費 Image Data URL 轉換 | FeiFei Tools</title>
+    <meta name="description" content="免費線上圖片轉 Base64 工具，拖曳圖片即可產生 Data URL，可選擇轉換為 WebP / JPEG / PNG 並調整品質，所有處理在瀏覽器中完成。">
+    <meta name="keywords" content="圖片轉Base64,Image Base64,Data URL,圖片轉碼,線上圖片工具">
+    <meta name="author" content="FeiFei">
+    <link rel="canonical" href="https://tool.feifei.tw/image-to-base64.html">
+
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://tool.feifei.tw/image-to-base64.html">
+    <meta property="og:title" content="圖片轉 Base64 | FeiFei Tools">
+    <meta property="og:description" content="免費線上圖片轉 Base64 Data URL 工具。">
+    <meta property="og:image" content="https://tool.feifei.tw/og-image.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="圖片轉 Base64 | FeiFei Tools">
+    <meta name="twitter:description" content="免費線上圖片轉 Base64 Data URL 工具。">
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-B20B804DQS"></script>
+    <script>window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-B20B804DQS');</script>
+
+    <script>(function() { const saved = localStorage.getItem('theme'); const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches; if (saved === 'dark' || (!saved && prefersDark)) { document.documentElement.classList.add('dark'); } })();</script>
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>tailwind.config = { darkMode: 'class', theme: { extend: { fontFamily: { sans: ['Noto Sans TC', 'system-ui', 'sans-serif'] } } } }</script>
+
+    <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;700&display=swap" rel="stylesheet">
+
+    <script type="application/ld+json">{ "@context": "https://schema.org", "@type": "WebApplication", "name": "圖片轉 Base64 工具", "url": "https://tool.feifei.tw/image-to-base64.html", "description": "將圖片轉換為 Base64 Data URL", "applicationCategory": "UtilityApplication", "operatingSystem": "Any", "offers": { "@type": "Offer", "price": "0", "priceCurrency": "TWD" } }</script>
+
+    <style>.touch-target { min-height: 44px; min-width: 44px; } .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }</style>
+</head>
+<body class="font-sans bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 antialiased">
+
+    <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 bg-blue-600 text-white px-4 py-2 rounded-lg z-[100]">跳至主要內容</a>
+
+    <header class="hidden md:block sticky top-0 z-40 bg-white/80 dark:bg-gray-800/80 backdrop-blur-lg border-b border-gray-200 dark:border-gray-700">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex items-center justify-between h-16">
+                <a href="index.html" class="flex items-center gap-2 touch-target"><span class="text-2xl">🛠️</span><span class="font-bold text-xl">FeiFei Tools</span></a>
+                <nav class="flex items-center gap-1"><a href="index.html" class="px-3 py-2 rounded-lg text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 text-sm">首頁</a><span class="text-gray-300 dark:text-gray-600">/</span><span class="px-3 py-2 text-gray-900 dark:text-white font-medium text-sm">圖片轉 Base64</span></nav>
+                <button id="theme-toggle-desktop" class="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors touch-target" aria-label="切換深色模式">
+                    <svg class="w-6 h-6 hidden dark:block text-yellow-400" fill="currentColor" viewBox="0 0 20 20"><path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+                    <svg class="w-6 h-6 block dark:hidden text-gray-600" fill="currentColor" viewBox="0 0 20 20"><path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/></svg>
+                </button>
+            </div>
+        </div>
+    </header>
+
+    <main id="main-content" class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-6 md:py-8 pb-24 md:pb-8">
+        <div class="mb-6">
+            <h1 class="text-2xl md:text-3xl font-bold mb-2 flex items-center gap-3"><span class="text-3xl">🖼️</span>圖片轉 Base64</h1>
+            <p class="text-gray-600 dark:text-gray-400">將圖片轉換為 Base64 Data URL，可直接嵌入 HTML / CSS / JSON</p>
+        </div>
+
+        <div class="space-y-6">
+            <!-- Upload -->
+            <section id="dropzone" class="bg-white dark:bg-gray-800 rounded-xl border-2 border-dashed border-gray-300 dark:border-gray-600 p-8 text-center hover:border-blue-500 dark:hover:border-blue-400 transition-colors cursor-pointer">
+                <label for="fileInput" class="cursor-pointer block">
+                    <svg class="w-12 h-12 mx-auto text-gray-400 dark:text-gray-500 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg>
+                    <p class="text-lg font-medium mb-1">選擇圖片或拖曳到此處</p>
+                    <p class="text-sm text-gray-500 dark:text-gray-400">支援 PNG、JPEG、GIF、WebP、SVG、AVIF</p>
+                    <input type="file" id="fileInput" class="hidden" accept="image/*">
+                </label>
+            </section>
+
+            <!-- Options -->
+            <section class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-5 md:p-6">
+                <h2 class="text-base font-semibold mb-4">輸出選項</h2>
+                <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                    <div>
+                        <label class="block text-sm font-medium mb-2">輸出格式</label>
+                        <select id="formatSel" class="w-full px-3 py-2 bg-gray-50 dark:bg-gray-900 border border-gray-300 dark:border-gray-600 rounded-lg text-sm focus:outline-none focus:border-blue-500">
+                            <option value="auto" selected>自動（保留原格式）</option>
+                            <option value="image/png">PNG</option>
+                            <option value="image/jpeg">JPEG</option>
+                            <option value="image/webp">WebP</option>
+                        </select>
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium mb-2">品質（JPEG / WebP）</label>
+                        <div class="flex items-center gap-3">
+                            <input type="range" id="qualityRange" min="10" max="100" value="90" class="flex-1 accent-blue-600">
+                            <span id="qualityVal" class="font-mono text-sm w-12 text-right">90%</span>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Output -->
+            <section id="outputSection" class="hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-5 md:p-6">
+                <div class="flex items-baseline justify-between gap-4 flex-wrap pb-3 mb-4 border-b border-gray-200 dark:border-gray-700">
+                    <h2 class="text-lg font-semibold text-gray-900 dark:text-white">結果</h2>
+                    <p id="meta" class="text-xs text-gray-500 dark:text-gray-400 font-mono"></p>
+                </div>
+
+                <div class="grid grid-cols-1 md:grid-cols-[200px_1fr] gap-4 mb-4">
+                    <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-3 flex items-center justify-center min-h-[160px] border border-gray-200 dark:border-gray-700" style="background-image: linear-gradient(45deg, #e5e7eb 25%, transparent 25%), linear-gradient(-45deg, #e5e7eb 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #e5e7eb 75%), linear-gradient(-45deg, transparent 75%, #e5e7eb 75%); background-size: 16px 16px; background-position: 0 0, 0 8px, 8px -8px, 8px 0px;">
+                        <img id="preview" alt="預覽" class="max-w-full max-h-[200px] rounded">
+                    </div>
+                    <div class="grid grid-cols-2 gap-2 text-sm">
+                        <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-3 border border-gray-200 dark:border-gray-700">
+                            <div class="text-xs text-gray-500 dark:text-gray-400 mb-1">原始大小</div>
+                            <div id="origSize" class="font-mono">—</div>
+                        </div>
+                        <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-3 border border-gray-200 dark:border-gray-700">
+                            <div class="text-xs text-gray-500 dark:text-gray-400 mb-1">Base64 大小</div>
+                            <div id="b64Size" class="font-mono">—</div>
+                        </div>
+                        <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-3 border border-gray-200 dark:border-gray-700">
+                            <div class="text-xs text-gray-500 dark:text-gray-400 mb-1">尺寸</div>
+                            <div id="dim" class="font-mono">—</div>
+                        </div>
+                        <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-3 border border-gray-200 dark:border-gray-700">
+                            <div class="text-xs text-gray-500 dark:text-gray-400 mb-1">MIME</div>
+                            <div id="mime" class="font-mono text-xs">—</div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Actions -->
+                <div class="flex flex-wrap gap-2 mb-3">
+                    <button data-mode="dataurl" class="format-btn px-3 py-1.5 text-xs font-medium rounded-md bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300">Data URL</button>
+                    <button data-mode="base64" class="format-btn px-3 py-1.5 text-xs font-medium rounded-md text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600">純 Base64</button>
+                    <button data-mode="html" class="format-btn px-3 py-1.5 text-xs font-medium rounded-md text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600">&lt;img&gt;</button>
+                    <button data-mode="css" class="format-btn px-3 py-1.5 text-xs font-medium rounded-md text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600">CSS background</button>
+
+                    <div class="ml-auto flex gap-2">
+                        <button id="copyBtn" class="inline-flex items-center gap-1 px-3 py-1.5 bg-blue-600 hover:bg-blue-700 text-white text-xs font-medium rounded-md transition-colors">
+                            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/></svg>
+                            複製
+                        </button>
+                        <button id="downloadBtn" class="inline-flex items-center gap-1 px-3 py-1.5 bg-white hover:bg-gray-50 dark:bg-gray-700 dark:hover:bg-gray-600 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 text-xs font-medium rounded-md transition-colors">下載 .txt</button>
+                    </div>
+                </div>
+
+                <textarea id="outputArea" readonly spellcheck="false" placeholder="輸出將顯示於此…"
+                    class="w-full h-56 bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2 font-mono text-xs leading-relaxed text-gray-800 dark:text-gray-100 resize-y focus:outline-none break-all"></textarea>
+            </section>
+
+            <!-- Info -->
+            <div class="bg-blue-50 dark:bg-blue-900/20 rounded-xl p-4 text-sm text-blue-800 dark:text-blue-200">
+                <p class="font-medium mb-1">使用說明</p>
+                <ul class="list-disc list-inside space-y-1 text-blue-700 dark:text-blue-300">
+                    <li>選擇「自動」會保留原始格式；若選擇其他格式則透過 Canvas 重新編碼</li>
+                    <li>Base64 體積約為原始檔案的 4/3，過大圖片不建議直接嵌入</li>
+                    <li>SVG 與 GIF 動畫若重新編碼會失去向量 / 動畫特性</li>
+                    <li>所有處理皆在瀏覽器本地完成，圖片不會上傳到任何伺服器</li>
+                </ul>
+            </div>
+        </div>
+    </main>
+
+    <nav class="md:hidden fixed bottom-0 left-0 right-0 z-50 bg-white/90 dark:bg-gray-800/90 backdrop-blur-lg border-t border-gray-200 dark:border-gray-700" style="padding-bottom: env(safe-area-inset-bottom, 0);">
+        <div class="grid grid-cols-5 h-16">
+            <a href="index.html" class="flex flex-col items-center justify-center text-gray-600 dark:text-gray-400 touch-target"><svg class="w-6 h-6" fill="currentColor" viewBox="0 0 20 20"><path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z"/></svg><span class="text-xs mt-0.5">首頁</span></a>
+            <a href="text-stats.html" class="flex flex-col items-center justify-center text-gray-600 dark:text-gray-400 touch-target"><svg class="w-6 h-6" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4z" clip-rule="evenodd"/></svg><span class="text-xs mt-0.5">文字</span></a>
+            <a href="pdf-to-png.html" class="flex flex-col items-center justify-center text-blue-600 dark:text-blue-400 touch-target"><svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg><span class="text-xs mt-0.5 font-medium">圖片</span></a>
+            <a href="encry.html" class="flex flex-col items-center justify-center text-gray-600 dark:text-gray-400 touch-target"><svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/></svg><span class="text-xs mt-0.5">開發</span></a>
+            <button id="theme-toggle-mobile" class="flex flex-col items-center justify-center text-gray-600 dark:text-gray-400 touch-target"><svg class="w-6 h-6 hidden dark:block" fill="currentColor" viewBox="0 0 20 20"><path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0z"/></svg><svg class="w-6 h-6 block dark:hidden" fill="currentColor" viewBox="0 0 20 20"><path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/></svg><span class="text-xs mt-0.5">主題</span></button>
+        </div>
+    </nav>
+
+    <div id="toast" class="fixed bottom-24 md:bottom-8 left-1/2 -translate-x-1/2 bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 px-4 py-2 rounded-lg shadow-lg transform transition-all duration-300 opacity-0 translate-y-4 pointer-events-none z-[60]"><span id="toast-message"></span></div>
+
+    <script>
+        function toggleTheme() { const isDark = document.documentElement.classList.toggle('dark'); localStorage.setItem('theme', isDark ? 'dark' : 'light'); }
+        document.getElementById('theme-toggle-desktop')?.addEventListener('click', toggleTheme);
+        document.getElementById('theme-toggle-mobile')?.addEventListener('click', toggleTheme);
+
+        function showToast(msg) {
+            const toast = document.getElementById('toast');
+            document.getElementById('toast-message').textContent = msg;
+            toast.classList.remove('opacity-0', 'translate-y-4', 'pointer-events-none');
+            toast.classList.add('opacity-100', 'translate-y-0');
+            setTimeout(() => { toast.classList.add('opacity-0', 'translate-y-4', 'pointer-events-none'); toast.classList.remove('opacity-100', 'translate-y-0'); }, 2000);
+        }
+
+        const dropzone = document.getElementById('dropzone');
+        const fileInput = document.getElementById('fileInput');
+        const formatSel = document.getElementById('formatSel');
+        const qualityRange = document.getElementById('qualityRange');
+        const qualityVal = document.getElementById('qualityVal');
+        const outputSection = document.getElementById('outputSection');
+        const preview = document.getElementById('preview');
+        const origSize = document.getElementById('origSize');
+        const b64Size = document.getElementById('b64Size');
+        const dimEl = document.getElementById('dim');
+        const mimeEl = document.getElementById('mime');
+        const outputArea = document.getElementById('outputArea');
+        const metaEl = document.getElementById('meta');
+
+        let currentDataUrl = '';
+        let currentMime = '';
+        let currentName = 'image';
+        let currentMode = 'dataurl';
+
+        qualityRange.addEventListener('input', () => {
+            qualityVal.textContent = qualityRange.value + '%';
+            if (currentFile) processFile(currentFile);
+        });
+        formatSel.addEventListener('change', () => { if (currentFile) processFile(currentFile); });
+
+        let currentFile = null;
+
+        fileInput.addEventListener('change', e => { const f = e.target.files[0]; if (f) handleFile(f); fileInput.value = ''; });
+
+        ['dragenter', 'dragover'].forEach(evt =>
+            dropzone.addEventListener(evt, e => { e.preventDefault(); dropzone.classList.add('border-blue-500', 'dark:border-blue-400', 'bg-blue-50', 'dark:bg-blue-900/10'); })
+        );
+        ['dragleave', 'drop'].forEach(evt =>
+            dropzone.addEventListener(evt, e => { e.preventDefault(); dropzone.classList.remove('border-blue-500', 'dark:border-blue-400', 'bg-blue-50', 'dark:bg-blue-900/10'); })
+        );
+        dropzone.addEventListener('drop', e => {
+            const f = e.dataTransfer.files && e.dataTransfer.files[0];
+            if (f) handleFile(f);
+        });
+
+        async function handleFile(file) {
+            if (!file.type.startsWith('image/')) {
+                showToast('請選擇圖片檔案');
+                return;
+            }
+            currentFile = file;
+            currentName = file.name.replace(/\.[^.]+$/, '') || 'image';
+            await processFile(file);
+        }
+
+        function formatBytes(n) {
+            if (n < 1024) return n + ' B';
+            if (n < 1024 * 1024) return (n / 1024).toFixed(1) + ' KB';
+            return (n / 1048576).toFixed(2) + ' MB';
+        }
+
+        async function processFile(file) {
+            const targetFormat = formatSel.value;
+            const quality = parseInt(qualityRange.value, 10) / 100;
+
+            if (targetFormat === 'auto') {
+                const dataUrl = await readAsDataURL(file);
+                currentDataUrl = dataUrl;
+                currentMime = file.type;
+                await renderImage(dataUrl, file.size);
+            } else {
+                const dataUrl = await transcode(file, targetFormat, quality);
+                currentDataUrl = dataUrl;
+                currentMime = targetFormat;
+                await renderImage(dataUrl, file.size);
+            }
+        }
+
+        function readAsDataURL(file) {
+            return new Promise((resolve, reject) => {
+                const r = new FileReader();
+                r.onload = e => resolve(e.target.result);
+                r.onerror = reject;
+                r.readAsDataURL(file);
+            });
+        }
+
+        function transcode(file, format, quality) {
+            return new Promise(async (resolve, reject) => {
+                const url = URL.createObjectURL(file);
+                const img = new Image();
+                img.onload = () => {
+                    const canvas = document.createElement('canvas');
+                    canvas.width = img.naturalWidth;
+                    canvas.height = img.naturalHeight;
+                    const ctx = canvas.getContext('2d');
+                    ctx.drawImage(img, 0, 0);
+                    URL.revokeObjectURL(url);
+                    try {
+                        resolve(canvas.toDataURL(format, quality));
+                    } catch (e) { reject(e); }
+                };
+                img.onerror = () => { URL.revokeObjectURL(url); reject(new Error('圖片載入失敗')); };
+                img.src = url;
+            });
+        }
+
+        async function renderImage(dataUrl, origBytes) {
+            preview.src = dataUrl;
+            await new Promise(r => { preview.onload = r; });
+            outputSection.classList.remove('hidden');
+
+            // sizes
+            const b64Bytes = Math.ceil(dataUrl.length * 0.75); // rough
+            origSize.textContent = formatBytes(origBytes);
+            b64Size.textContent = formatBytes(dataUrl.length);
+            dimEl.textContent = `${preview.naturalWidth} × ${preview.naturalHeight}`;
+            mimeEl.textContent = currentMime;
+            metaEl.textContent = `${formatBytes(dataUrl.length)} · ${currentMime}`;
+
+            updateOutput();
+        }
+
+        function updateOutput() {
+            if (!currentDataUrl) return;
+            const b64 = currentDataUrl.split(',')[1] || '';
+            if (currentMode === 'dataurl') {
+                outputArea.value = currentDataUrl;
+            } else if (currentMode === 'base64') {
+                outputArea.value = b64;
+            } else if (currentMode === 'html') {
+                outputArea.value = `<img src="${currentDataUrl}" alt="">`;
+            } else if (currentMode === 'css') {
+                outputArea.value = `background-image: url("${currentDataUrl}");`;
+            }
+        }
+
+        document.querySelectorAll('.format-btn').forEach(btn => {
+            btn.addEventListener('click', () => {
+                currentMode = btn.dataset.mode;
+                document.querySelectorAll('.format-btn').forEach(b => {
+                    b.className = 'format-btn px-3 py-1.5 text-xs font-medium rounded-md text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600';
+                });
+                btn.className = 'format-btn px-3 py-1.5 text-xs font-medium rounded-md bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300';
+                updateOutput();
+            });
+        });
+
+        document.getElementById('copyBtn').addEventListener('click', async () => {
+            if (!outputArea.value) return;
+            try { await navigator.clipboard.writeText(outputArea.value); showToast('已複製'); }
+            catch { outputArea.select(); document.execCommand('copy'); showToast('已複製'); }
+        });
+
+        document.getElementById('downloadBtn').addEventListener('click', () => {
+            if (!outputArea.value) return;
+            const blob = new Blob([outputArea.value], { type: 'text/plain;charset=utf-8' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url; a.download = `${currentName}_base64.txt`;
+            document.body.appendChild(a); a.click(); a.remove();
+            URL.revokeObjectURL(url);
+            showToast('已下載 .txt');
+        });
+    </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -253,7 +253,7 @@
                             <span class="text-3xl flex-shrink-0" aria-hidden="true">📃</span>
                             <div class="flex-1 min-w-0">
                                 <h3 class="font-semibold text-gray-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">Word 批次取代工具</h3>
-                                <p class="text-sm text-gray-500 dark:text-gray-400 mt-1 line-clamp-2">線上工具</p>
+                                <p class="text-sm text-gray-500 dark:text-gray-400 mt-1 line-clamp-2">免費線上 Word 批次取代工具，一次處理多個 .docx 檔案，套用多條取代規則，保留原始格...</p>
                             </div>
                             <svg class="w-5 h-5 text-gray-400 group-hover:text-blue-500 group-hover:translate-x-1 transition-all flex-shrink-0 mt-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
                         </div>
@@ -292,6 +292,17 @@
                         </div>
                     </a>
 
+                    <a href="image-to-base64.html" class="tool-card group block p-4 bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 hover:border-blue-500 dark:hover:border-blue-400 hover:shadow-lg hover:shadow-blue-500/10 transition-all touch-target" data-keywords="圖片 base64 data url 編碼 image to base64 dataurl">
+                        <div class="flex items-start gap-3">
+                            <span class="text-3xl flex-shrink-0" aria-hidden="true">🖼️</span>
+                            <div class="flex-1 min-w-0">
+                                <h3 class="font-semibold text-gray-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">圖片轉 Base64</h3>
+                                <p class="text-sm text-gray-500 dark:text-gray-400 mt-1 line-clamp-2">免費線上圖片轉 Base64 工具，拖曳圖片即可產生 Data URL，可選擇轉換為 WebP...</p>
+                            </div>
+                            <svg class="w-5 h-5 text-gray-400 group-hover:text-blue-500 group-hover:translate-x-1 transition-all flex-shrink-0 mt-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+                        </div>
+                    </a>
+
                     <a href="pdf-to-png.html" class="tool-card group block p-4 bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 hover:border-blue-500 dark:hover:border-blue-400 hover:shadow-lg hover:shadow-blue-500/10 transition-all touch-target" data-keywords="pdf png 轉換 圖片 convert">
                         <div class="flex items-start gap-3">
                             <span class="text-3xl flex-shrink-0" aria-hidden="true">📄</span>
@@ -303,12 +314,12 @@
                         </div>
                     </a>
 
-                    <a href="pdf-to-txt.html" class="tool-card group block p-4 bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 hover:border-blue-500 dark:hover:border-blue-400 hover:shadow-lg hover:shadow-blue-500/10 transition-all touch-target" data-keywords="pdf txt 純文字 擷取 文字提取 extract text">
+                    <a href="pdf-to-txt.html" class="tool-card group block p-4 bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 hover:border-blue-500 dark:hover:border-blue-400 hover:shadow-lg hover:shadow-blue-500/10 transition-all touch-target" data-keywords="pdf txt 純文字 擷取 抽取 文字 extract text">
                         <div class="flex items-start gap-3">
-                            <span class="text-3xl flex-shrink-0" aria-hidden="true">📝</span>
+                            <span class="text-3xl flex-shrink-0" aria-hidden="true">📄</span>
                             <div class="flex-1 min-w-0">
-                                <h3 class="font-semibold text-gray-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">PDF 轉 TXT 純文字擷取</h3>
-                                <p class="text-sm text-gray-500 dark:text-gray-400 mt-1 line-clamp-2">免費線上 PDF 文字擷取工具，將 PDF 解析為純文字，支援多頁複製與下載，全程在瀏覽器中完成。</p>
+                                <h3 class="font-semibold text-gray-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">PDF 轉 TXT 純文字擷取工具</h3>
+                                <p class="text-sm text-gray-500 dark:text-gray-400 mt-1 line-clamp-2">免費線上 PDF 轉 TXT 工具，將 PDF 文件解析為純文字，支援多頁擷取、複製與下載，所...</p>
                             </div>
                             <svg class="w-5 h-5 text-gray-400 group-hover:text-blue-500 group-hover:translate-x-1 transition-all flex-shrink-0 mt-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
                         </div>
@@ -320,17 +331,6 @@
                             <div class="flex-1 min-w-0">
                                 <h3 class="font-semibold text-gray-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">縮小圖片工具</h3>
                                 <p class="text-sm text-gray-500 dark:text-gray-400 mt-1 line-clamp-2">免費線上圖片縮放工具，快速調整圖片寬度或高度，自動等比例縮放。</p>
-                            </div>
-                            <svg class="w-5 h-5 text-gray-400 group-hover:text-blue-500 group-hover:translate-x-1 transition-all flex-shrink-0 mt-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
-                        </div>
-                    </a>
-
-                    <a href="image-to-base64.html" class="tool-card group block p-4 bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 hover:border-blue-500 dark:hover:border-blue-400 hover:shadow-lg hover:shadow-blue-500/10 transition-all touch-target" data-keywords="圖片 base64 data url 編碼 image to base64 dataurl">
-                        <div class="flex items-start gap-3">
-                            <span class="text-3xl flex-shrink-0" aria-hidden="true">🖼️</span>
-                            <div class="flex-1 min-w-0">
-                                <h3 class="font-semibold text-gray-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">圖片轉 Base64</h3>
-                                <p class="text-sm text-gray-500 dark:text-gray-400 mt-1 line-clamp-2">免費線上圖片轉 Base64 Data URL 工具，可選擇輸出 PNG / JPEG / WebP，支援 HTML、CSS 片段複製。</p>
                             </div>
                             <svg class="w-5 h-5 text-gray-400 group-hover:text-blue-500 group-hover:translate-x-1 transition-all flex-shrink-0 mt-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
                         </div>
@@ -402,6 +402,28 @@
                         </div>
                     </a>
 
+                    <a href="json-formatter.html" class="tool-card group block p-4 bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 hover:border-blue-500 dark:hover:border-blue-400 hover:shadow-lg hover:shadow-blue-500/10 transition-all touch-target" data-keywords="json 格式化 美化 壓縮 驗證 樹狀 formatter prettify minify validate">
+                        <div class="flex items-start gap-3">
+                            <span class="text-3xl flex-shrink-0" aria-hidden="true">{ }</span>
+                            <div class="flex-1 min-w-0">
+                                <h3 class="font-semibold text-gray-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">JSON 格式化工具</h3>
+                                <p class="text-sm text-gray-500 dark:text-gray-400 mt-1 line-clamp-2">免費線上 JSON 格式化工具，支援美化、壓縮、驗證、樹狀檢視，自動偵測錯誤位置，所有處理在瀏...</p>
+                            </div>
+                            <svg class="w-5 h-5 text-gray-400 group-hover:text-blue-500 group-hover:translate-x-1 transition-all flex-shrink-0 mt-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+                        </div>
+                    </a>
+
+                    <a href="jwt-decoder.html" class="tool-card group block p-4 bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 hover:border-blue-500 dark:hover:border-blue-400 hover:shadow-lg hover:shadow-blue-500/10 transition-all touch-target" data-keywords="jwt token 解碼 解析 jwt decoder 認證 auth">
+                        <div class="flex items-start gap-3">
+                            <span class="text-3xl flex-shrink-0" aria-hidden="true">🔑</span>
+                            <div class="flex-1 min-w-0">
+                                <h3 class="font-semibold text-gray-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">JWT 解碼器</h3>
+                                <p class="text-sm text-gray-500 dark:text-gray-400 mt-1 line-clamp-2">免費線上 JWT 解碼器，貼上 Token 即可解析 Header、Payload、Signa...</p>
+                            </div>
+                            <svg class="w-5 h-5 text-gray-400 group-hover:text-blue-500 group-hover:translate-x-1 transition-all flex-shrink-0 mt-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+                        </div>
+                    </a>
+
                     <a href="markdown-viewer.html" class="tool-card group block p-4 bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 hover:border-blue-500 dark:hover:border-blue-400 hover:shadow-lg hover:shadow-blue-500/10 transition-all touch-target" data-keywords="markdown 預覽 上傳 檢視 viewer preview md gfm">
                         <div class="flex items-start gap-3">
                             <span class="text-3xl flex-shrink-0" aria-hidden="true">📖</span>
@@ -413,23 +435,12 @@
                         </div>
                     </a>
 
-                    <a href="windows-to-wsl.html" class="tool-card group block p-4 bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 hover:border-blue-500 dark:hover:border-blue-400 hover:shadow-lg hover:shadow-blue-500/10 transition-all touch-target" data-keywords="windows wsl linux 路徑 轉換 path">
+                    <a href="qr-generator.html" class="tool-card group block p-4 bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 hover:border-blue-500 dark:hover:border-blue-400 hover:shadow-lg hover:shadow-blue-500/10 transition-all touch-target" data-keywords="qr code 二維碼 產生器 generator png svg">
                         <div class="flex items-start gap-3">
-                            <span class="text-3xl flex-shrink-0" aria-hidden="true">🪟</span>
+                            <span class="text-3xl flex-shrink-0" aria-hidden="true">▦</span>
                             <div class="flex-1 min-w-0">
-                                <h3 class="font-semibold text-gray-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">Windows 轉 WSL 路徑</h3>
-                                <p class="text-sm text-gray-500 dark:text-gray-400 mt-1 line-clamp-2">免費線上 Windows 路徑轉 WSL 路徑工具，支援磁碟代號、網路路徑轉換，自動儲存轉換記錄。</p>
-                            </div>
-                            <svg class="w-5 h-5 text-gray-400 group-hover:text-blue-500 group-hover:translate-x-1 transition-all flex-shrink-0 mt-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
-                        </div>
-                    </a>
-
-                    <a href="json-formatter.html" class="tool-card group block p-4 bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 hover:border-blue-500 dark:hover:border-blue-400 hover:shadow-lg hover:shadow-blue-500/10 transition-all touch-target" data-keywords="json 格式化 美化 壓縮 驗證 樹狀 formatter prettify minify validate">
-                        <div class="flex items-start gap-3">
-                            <span class="text-3xl flex-shrink-0" aria-hidden="true">{ }</span>
-                            <div class="flex-1 min-w-0">
-                                <h3 class="font-semibold text-gray-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">JSON 格式化工具</h3>
-                                <p class="text-sm text-gray-500 dark:text-gray-400 mt-1 line-clamp-2">免費線上 JSON 美化、壓縮、驗證與樹狀檢視，自動標示錯誤位置，可下載 .json。</p>
+                                <h3 class="font-semibold text-gray-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">QR Code 產生器</h3>
+                                <p class="text-sm text-gray-500 dark:text-gray-400 mt-1 line-clamp-2">免費線上 QR Code 產生器，支援文字、網址、自訂顏色與容錯等級，可下載 PNG 與 SV...</p>
                             </div>
                             <svg class="w-5 h-5 text-gray-400 group-hover:text-blue-500 group-hover:translate-x-1 transition-all flex-shrink-0 mt-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
                         </div>
@@ -440,29 +451,18 @@
                             <span class="text-3xl flex-shrink-0" aria-hidden="true">🔗</span>
                             <div class="flex-1 min-w-0">
                                 <h3 class="font-semibold text-gray-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">URL 編解碼工具</h3>
-                                <p class="text-sm text-gray-500 dark:text-gray-400 mt-1 line-clamp-2">免費線上 URL Encode / Decode 與查詢字串拆解工具，支援 encodeURIComponent / encodeURI。</p>
+                                <p class="text-sm text-gray-500 dark:text-gray-400 mt-1 line-clamp-2">免費線上 URL 編解碼工具，支援 encodeURIComponent / encodeUR...</p>
                             </div>
                             <svg class="w-5 h-5 text-gray-400 group-hover:text-blue-500 group-hover:translate-x-1 transition-all flex-shrink-0 mt-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
                         </div>
                     </a>
 
-                    <a href="jwt-decoder.html" class="tool-card group block p-4 bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 hover:border-blue-500 dark:hover:border-blue-400 hover:shadow-lg hover:shadow-blue-500/10 transition-all touch-target" data-keywords="jwt token 解碼 解析 jwt decoder 認證 auth">
+                    <a href="windows-to-wsl.html" class="tool-card group block p-4 bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 hover:border-blue-500 dark:hover:border-blue-400 hover:shadow-lg hover:shadow-blue-500/10 transition-all touch-target" data-keywords="windows wsl linux 路徑 轉換 path">
                         <div class="flex items-start gap-3">
-                            <span class="text-3xl flex-shrink-0" aria-hidden="true">🔑</span>
+                            <span class="text-3xl flex-shrink-0" aria-hidden="true">🪟</span>
                             <div class="flex-1 min-w-0">
-                                <h3 class="font-semibold text-gray-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">JWT 解碼器</h3>
-                                <p class="text-sm text-gray-500 dark:text-gray-400 mt-1 line-clamp-2">免費線上 JWT Token 解析工具，分別顯示 Header、Payload、Signature，自動轉換時間欄位。</p>
-                            </div>
-                            <svg class="w-5 h-5 text-gray-400 group-hover:text-blue-500 group-hover:translate-x-1 transition-all flex-shrink-0 mt-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
-                        </div>
-                    </a>
-
-                    <a href="qr-generator.html" class="tool-card group block p-4 bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 hover:border-blue-500 dark:hover:border-blue-400 hover:shadow-lg hover:shadow-blue-500/10 transition-all touch-target" data-keywords="qr code 二維碼 產生器 generator png svg">
-                        <div class="flex items-start gap-3">
-                            <span class="text-3xl flex-shrink-0" aria-hidden="true">▦</span>
-                            <div class="flex-1 min-w-0">
-                                <h3 class="font-semibold text-gray-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">QR Code 產生器</h3>
-                                <p class="text-sm text-gray-500 dark:text-gray-400 mt-1 line-clamp-2">免費線上 QR Code 產生器，支援自訂顏色、容錯等級、輸出尺寸，可下載 PNG 與 SVG。</p>
+                                <h3 class="font-semibold text-gray-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">Windows 轉 WSL 路徑</h3>
+                                <p class="text-sm text-gray-500 dark:text-gray-400 mt-1 line-clamp-2">免費線上 Windows 路徑轉 WSL 路徑工具，支援磁碟代號、網路路徑轉換，自動儲存轉換記錄。</p>
                             </div>
                             <svg class="w-5 h-5 text-gray-400 group-hover:text-blue-500 group-hover:translate-x-1 transition-all flex-shrink-0 mt-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
                         </div>

--- a/index.html
+++ b/index.html
@@ -324,6 +324,17 @@
                             <svg class="w-5 h-5 text-gray-400 group-hover:text-blue-500 group-hover:translate-x-1 transition-all flex-shrink-0 mt-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
                         </div>
                     </a>
+
+                    <a href="image-to-base64.html" class="tool-card group block p-4 bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 hover:border-blue-500 dark:hover:border-blue-400 hover:shadow-lg hover:shadow-blue-500/10 transition-all touch-target" data-keywords="圖片 base64 data url 編碼 image to base64 dataurl">
+                        <div class="flex items-start gap-3">
+                            <span class="text-3xl flex-shrink-0" aria-hidden="true">🖼️</span>
+                            <div class="flex-1 min-w-0">
+                                <h3 class="font-semibold text-gray-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">圖片轉 Base64</h3>
+                                <p class="text-sm text-gray-500 dark:text-gray-400 mt-1 line-clamp-2">免費線上圖片轉 Base64 Data URL 工具，可選擇輸出 PNG / JPEG / WebP，支援 HTML、CSS 片段複製。</p>
+                            </div>
+                            <svg class="w-5 h-5 text-gray-400 group-hover:text-blue-500 group-hover:translate-x-1 transition-all flex-shrink-0 mt-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+                        </div>
+                    </a>
 <!--IMAGE_TOOLS_END-->
                 </div>
             </div>
@@ -408,6 +419,50 @@
                             <div class="flex-1 min-w-0">
                                 <h3 class="font-semibold text-gray-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">Windows 轉 WSL 路徑</h3>
                                 <p class="text-sm text-gray-500 dark:text-gray-400 mt-1 line-clamp-2">免費線上 Windows 路徑轉 WSL 路徑工具，支援磁碟代號、網路路徑轉換，自動儲存轉換記錄。</p>
+                            </div>
+                            <svg class="w-5 h-5 text-gray-400 group-hover:text-blue-500 group-hover:translate-x-1 transition-all flex-shrink-0 mt-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+                        </div>
+                    </a>
+
+                    <a href="json-formatter.html" class="tool-card group block p-4 bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 hover:border-blue-500 dark:hover:border-blue-400 hover:shadow-lg hover:shadow-blue-500/10 transition-all touch-target" data-keywords="json 格式化 美化 壓縮 驗證 樹狀 formatter prettify minify validate">
+                        <div class="flex items-start gap-3">
+                            <span class="text-3xl flex-shrink-0" aria-hidden="true">{ }</span>
+                            <div class="flex-1 min-w-0">
+                                <h3 class="font-semibold text-gray-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">JSON 格式化工具</h3>
+                                <p class="text-sm text-gray-500 dark:text-gray-400 mt-1 line-clamp-2">免費線上 JSON 美化、壓縮、驗證與樹狀檢視，自動標示錯誤位置，可下載 .json。</p>
+                            </div>
+                            <svg class="w-5 h-5 text-gray-400 group-hover:text-blue-500 group-hover:translate-x-1 transition-all flex-shrink-0 mt-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+                        </div>
+                    </a>
+
+                    <a href="url-encode.html" class="tool-card group block p-4 bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 hover:border-blue-500 dark:hover:border-blue-400 hover:shadow-lg hover:shadow-blue-500/10 transition-all touch-target" data-keywords="url 編碼 解碼 encode decode encodeURIComponent 查詢字串 query string">
+                        <div class="flex items-start gap-3">
+                            <span class="text-3xl flex-shrink-0" aria-hidden="true">🔗</span>
+                            <div class="flex-1 min-w-0">
+                                <h3 class="font-semibold text-gray-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">URL 編解碼工具</h3>
+                                <p class="text-sm text-gray-500 dark:text-gray-400 mt-1 line-clamp-2">免費線上 URL Encode / Decode 與查詢字串拆解工具，支援 encodeURIComponent / encodeURI。</p>
+                            </div>
+                            <svg class="w-5 h-5 text-gray-400 group-hover:text-blue-500 group-hover:translate-x-1 transition-all flex-shrink-0 mt-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+                        </div>
+                    </a>
+
+                    <a href="jwt-decoder.html" class="tool-card group block p-4 bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 hover:border-blue-500 dark:hover:border-blue-400 hover:shadow-lg hover:shadow-blue-500/10 transition-all touch-target" data-keywords="jwt token 解碼 解析 jwt decoder 認證 auth">
+                        <div class="flex items-start gap-3">
+                            <span class="text-3xl flex-shrink-0" aria-hidden="true">🔑</span>
+                            <div class="flex-1 min-w-0">
+                                <h3 class="font-semibold text-gray-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">JWT 解碼器</h3>
+                                <p class="text-sm text-gray-500 dark:text-gray-400 mt-1 line-clamp-2">免費線上 JWT Token 解析工具，分別顯示 Header、Payload、Signature，自動轉換時間欄位。</p>
+                            </div>
+                            <svg class="w-5 h-5 text-gray-400 group-hover:text-blue-500 group-hover:translate-x-1 transition-all flex-shrink-0 mt-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+                        </div>
+                    </a>
+
+                    <a href="qr-generator.html" class="tool-card group block p-4 bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 hover:border-blue-500 dark:hover:border-blue-400 hover:shadow-lg hover:shadow-blue-500/10 transition-all touch-target" data-keywords="qr code 二維碼 產生器 generator png svg">
+                        <div class="flex items-start gap-3">
+                            <span class="text-3xl flex-shrink-0" aria-hidden="true">▦</span>
+                            <div class="flex-1 min-w-0">
+                                <h3 class="font-semibold text-gray-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">QR Code 產生器</h3>
+                                <p class="text-sm text-gray-500 dark:text-gray-400 mt-1 line-clamp-2">免費線上 QR Code 產生器，支援自訂顏色、容錯等級、輸出尺寸，可下載 PNG 與 SVG。</p>
                             </div>
                             <svg class="w-5 h-5 text-gray-400 group-hover:text-blue-500 group-hover:translate-x-1 transition-all flex-shrink-0 mt-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
                         </div>

--- a/json-formatter.html
+++ b/json-formatter.html
@@ -1,0 +1,347 @@
+<!DOCTYPE html>
+<html lang="zh-TW" class="scroll-smooth">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <!-- SEO -->
+    <title>JSON 格式化工具 - 線上免費美化、壓縮、驗證 JSON | FeiFei Tools</title>
+    <meta name="description" content="免費線上 JSON 格式化工具，支援美化、壓縮、驗證、樹狀檢視，自動偵測錯誤位置，所有處理在瀏覽器中完成。">
+    <meta name="keywords" content="JSON格式化,JSON美化,JSON壓縮,JSON驗證,線上JSON工具">
+    <meta name="author" content="FeiFei">
+    <link rel="canonical" href="https://tool.feifei.tw/json-formatter.html">
+
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://tool.feifei.tw/json-formatter.html">
+    <meta property="og:title" content="JSON 格式化工具 | FeiFei Tools">
+    <meta property="og:description" content="免費線上 JSON 美化、壓縮、驗證、樹狀檢視。">
+    <meta property="og:image" content="https://tool.feifei.tw/og-image.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="JSON 格式化工具 | FeiFei Tools">
+    <meta name="twitter:description" content="免費線上 JSON 美化、壓縮、驗證工具。">
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-B20B804DQS"></script>
+    <script>window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-B20B804DQS');</script>
+
+    <script>(function() { const saved = localStorage.getItem('theme'); const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches; if (saved === 'dark' || (!saved && prefersDark)) { document.documentElement.classList.add('dark'); } })();</script>
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>tailwind.config = { darkMode: 'class', theme: { extend: { fontFamily: { sans: ['Noto Sans TC', 'system-ui', 'sans-serif'] } } } }</script>
+
+    <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;700&display=swap" rel="stylesheet">
+
+    <script type="application/ld+json">{ "@context": "https://schema.org", "@type": "WebApplication", "name": "JSON 格式化工具", "url": "https://tool.feifei.tw/json-formatter.html", "description": "JSON 美化、壓縮、驗證工具", "applicationCategory": "DeveloperApplication", "operatingSystem": "Any", "offers": { "@type": "Offer", "price": "0", "priceCurrency": "TWD" } }</script>
+
+    <style>
+        .touch-target { min-height: 44px; min-width: 44px; }
+        .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }
+        .json-key { color: #0369a1; }
+        .dark .json-key { color: #7dd3fc; }
+        .json-string { color: #15803d; }
+        .dark .json-string { color: #86efac; }
+        .json-number { color: #c2410c; }
+        .dark .json-number { color: #fdba74; }
+        .json-bool { color: #9333ea; }
+        .dark .json-bool { color: #d8b4fe; }
+        .json-null { color: #6b7280; font-style: italic; }
+        .dark .json-null { color: #9ca3af; }
+        details > summary { cursor: pointer; user-select: none; list-style: none; }
+        details > summary::-webkit-details-marker { display: none; }
+        details > summary::before { content: '▶'; display: inline-block; margin-right: 4px; font-size: 9px; transition: transform 0.15s; color: #6b7280; }
+        details[open] > summary::before { transform: rotate(90deg); }
+        .tree-block { padding-left: 1.5em; }
+    </style>
+</head>
+<body class="font-sans bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 antialiased">
+
+    <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 bg-blue-600 text-white px-4 py-2 rounded-lg z-[100]">跳至主要內容</a>
+
+    <header class="hidden md:block sticky top-0 z-40 bg-white/80 dark:bg-gray-800/80 backdrop-blur-lg border-b border-gray-200 dark:border-gray-700">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex items-center justify-between h-16">
+                <a href="index.html" class="flex items-center gap-2 touch-target"><span class="text-2xl">🛠️</span><span class="font-bold text-xl">FeiFei Tools</span></a>
+                <nav class="flex items-center gap-1"><a href="index.html" class="px-3 py-2 rounded-lg text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 text-sm">首頁</a><span class="text-gray-300 dark:text-gray-600">/</span><span class="px-3 py-2 text-gray-900 dark:text-white font-medium text-sm">JSON 格式化</span></nav>
+                <button id="theme-toggle-desktop" class="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors touch-target" aria-label="切換深色模式">
+                    <svg class="w-6 h-6 hidden dark:block text-yellow-400" fill="currentColor" viewBox="0 0 20 20"><path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+                    <svg class="w-6 h-6 block dark:hidden text-gray-600" fill="currentColor" viewBox="0 0 20 20"><path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/></svg>
+                </button>
+            </div>
+        </div>
+    </header>
+
+    <main id="main-content" class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 md:py-8 pb-24 md:pb-8">
+        <div class="mb-6">
+            <h1 class="text-2xl md:text-3xl font-bold mb-2 flex items-center gap-3"><span class="text-3xl">{ }</span>JSON 格式化工具</h1>
+            <p class="text-gray-600 dark:text-gray-400">JSON 美化、壓縮、驗證與樹狀檢視，自動標示錯誤位置</p>
+        </div>
+
+        <div class="space-y-4">
+            <!-- Toolbar -->
+            <div class="flex flex-wrap items-center gap-3">
+                <button id="formatBtn" class="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg transition-colors touch-target">
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h7"/></svg>
+                    美化
+                </button>
+                <button id="minifyBtn" class="inline-flex items-center gap-2 px-4 py-2 bg-white hover:bg-gray-50 dark:bg-gray-800 dark:hover:bg-gray-700 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 text-sm font-medium rounded-lg transition-colors touch-target">
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 12H4"/></svg>
+                    壓縮
+                </button>
+                <button id="validateBtn" class="inline-flex items-center gap-2 px-4 py-2 bg-white hover:bg-gray-50 dark:bg-gray-800 dark:hover:bg-gray-700 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 text-sm font-medium rounded-lg transition-colors touch-target">
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+                    驗證
+                </button>
+                <button id="sampleBtn" class="inline-flex items-center gap-2 px-4 py-2 bg-white hover:bg-gray-50 dark:bg-gray-800 dark:hover:bg-gray-700 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 text-sm font-medium rounded-lg transition-colors touch-target">範例</button>
+                <button id="clearBtn" class="inline-flex items-center gap-2 px-4 py-2 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 text-sm font-medium rounded-lg transition-colors touch-target">清除</button>
+
+                <div class="flex items-center gap-2 ml-auto">
+                    <label for="indentSel" class="text-sm text-gray-600 dark:text-gray-400">縮排</label>
+                    <select id="indentSel" class="px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg text-sm focus:outline-none focus:border-blue-500">
+                        <option value="2">2 空格</option>
+                        <option value="4">4 空格</option>
+                        <option value="\t">Tab</option>
+                    </select>
+                </div>
+            </div>
+
+            <!-- Status -->
+            <div id="status" class="hidden px-4 py-3 rounded-lg text-sm"></div>
+
+            <!-- Split panes -->
+            <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+                <!-- Input -->
+                <section class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden">
+                    <div class="flex items-center justify-between px-4 py-2.5 border-b border-gray-200 dark:border-gray-700">
+                        <h2 class="text-sm font-semibold text-gray-700 dark:text-gray-200">輸入</h2>
+                        <span id="inputStats" class="text-xs text-gray-500 dark:text-gray-400 font-mono">0 chars</span>
+                    </div>
+                    <textarea id="inputArea" spellcheck="false" placeholder='貼上 JSON，例如 {"name": "feifei"}'
+                        class="w-full h-[60vh] min-h-[400px] bg-white dark:bg-gray-800 border-0 px-4 py-3 font-mono text-sm leading-relaxed text-gray-800 dark:text-gray-100 resize-y focus:outline-none"></textarea>
+                </section>
+
+                <!-- Output -->
+                <section class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden">
+                    <div class="flex items-center justify-between px-4 py-2.5 border-b border-gray-200 dark:border-gray-700">
+                        <div class="flex items-center gap-1">
+                            <button id="tabText" class="px-2.5 py-1 rounded-md text-xs font-medium bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300">文字</button>
+                            <button id="tabTree" class="px-2.5 py-1 rounded-md text-xs font-medium text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">樹狀</button>
+                        </div>
+                        <div class="flex items-center gap-2">
+                            <span id="outputStats" class="text-xs text-gray-500 dark:text-gray-400 font-mono">— chars</span>
+                            <button id="copyBtn" class="px-2 py-1 text-xs text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md transition-colors" title="複製">複製</button>
+                            <button id="downloadBtn" class="px-2 py-1 text-xs text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md transition-colors" title="下載">下載</button>
+                        </div>
+                    </div>
+                    <textarea id="outputArea" spellcheck="false" readonly placeholder="格式化後的 JSON 將顯示於此…"
+                        class="w-full h-[60vh] min-h-[400px] bg-white dark:bg-gray-800 border-0 px-4 py-3 font-mono text-sm leading-relaxed text-gray-800 dark:text-gray-100 resize-y focus:outline-none"></textarea>
+                    <div id="treeView" class="hidden w-full h-[60vh] min-h-[400px] overflow-auto px-4 py-3 font-mono text-sm leading-relaxed text-gray-800 dark:text-gray-100"></div>
+                </section>
+            </div>
+
+            <!-- Info -->
+            <div class="bg-blue-50 dark:bg-blue-900/20 rounded-xl p-4 text-sm text-blue-800 dark:text-blue-200">
+                <p class="font-medium mb-1">使用說明</p>
+                <ul class="list-disc list-inside space-y-1 text-blue-700 dark:text-blue-300">
+                    <li>貼上 JSON 後點擊「美化」可格式化縮排，「壓縮」會移除所有空白</li>
+                    <li>「樹狀」檢視可以展開/收合物件與陣列</li>
+                    <li>錯誤訊息會標示具體的位置（行/列），方便除錯</li>
+                </ul>
+            </div>
+        </div>
+    </main>
+
+    <nav class="md:hidden fixed bottom-0 left-0 right-0 z-50 bg-white/90 dark:bg-gray-800/90 backdrop-blur-lg border-t border-gray-200 dark:border-gray-700" style="padding-bottom: env(safe-area-inset-bottom, 0);">
+        <div class="grid grid-cols-5 h-16">
+            <a href="index.html" class="flex flex-col items-center justify-center text-gray-600 dark:text-gray-400 touch-target"><svg class="w-6 h-6" fill="currentColor" viewBox="0 0 20 20"><path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z"/></svg><span class="text-xs mt-0.5">首頁</span></a>
+            <a href="text-stats.html" class="flex flex-col items-center justify-center text-gray-600 dark:text-gray-400 touch-target"><svg class="w-6 h-6" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4z" clip-rule="evenodd"/></svg><span class="text-xs mt-0.5">文字</span></a>
+            <a href="pdf-to-png.html" class="flex flex-col items-center justify-center text-gray-600 dark:text-gray-400 touch-target"><svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg><span class="text-xs mt-0.5">圖片</span></a>
+            <a href="encry.html" class="flex flex-col items-center justify-center text-blue-600 dark:text-blue-400 touch-target"><svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/></svg><span class="text-xs mt-0.5 font-medium">開發</span></a>
+            <button id="theme-toggle-mobile" class="flex flex-col items-center justify-center text-gray-600 dark:text-gray-400 touch-target"><svg class="w-6 h-6 hidden dark:block" fill="currentColor" viewBox="0 0 20 20"><path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0z"/></svg><svg class="w-6 h-6 block dark:hidden" fill="currentColor" viewBox="0 0 20 20"><path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/></svg><span class="text-xs mt-0.5">主題</span></button>
+        </div>
+    </nav>
+
+    <div id="toast" class="fixed bottom-24 md:bottom-8 left-1/2 -translate-x-1/2 bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 px-4 py-2 rounded-lg shadow-lg transform transition-all duration-300 opacity-0 translate-y-4 pointer-events-none z-[60]"><span id="toast-message"></span></div>
+
+    <script>
+        function toggleTheme() { const isDark = document.documentElement.classList.toggle('dark'); localStorage.setItem('theme', isDark ? 'dark' : 'light'); }
+        document.getElementById('theme-toggle-desktop')?.addEventListener('click', toggleTheme);
+        document.getElementById('theme-toggle-mobile')?.addEventListener('click', toggleTheme);
+
+        function showToast(msg, duration = 2000) {
+            const toast = document.getElementById('toast');
+            document.getElementById('toast-message').textContent = msg;
+            toast.classList.remove('opacity-0', 'translate-y-4', 'pointer-events-none');
+            toast.classList.add('opacity-100', 'translate-y-0');
+            setTimeout(() => { toast.classList.add('opacity-0', 'translate-y-4', 'pointer-events-none'); toast.classList.remove('opacity-100', 'translate-y-0'); }, duration);
+        }
+
+        const inputArea = document.getElementById('inputArea');
+        const outputArea = document.getElementById('outputArea');
+        const treeView = document.getElementById('treeView');
+        const statusEl = document.getElementById('status');
+        const inputStats = document.getElementById('inputStats');
+        const outputStats = document.getElementById('outputStats');
+        const indentSel = document.getElementById('indentSel');
+        const tabText = document.getElementById('tabText');
+        const tabTree = document.getElementById('tabTree');
+
+        function showStatus(type, msg) {
+            statusEl.classList.remove('hidden');
+            const styles = {
+                success: 'bg-green-50 dark:bg-green-900/20 text-green-800 dark:text-green-200 border-l-4 border-green-500',
+                error: 'bg-red-50 dark:bg-red-900/20 text-red-800 dark:text-red-200 border-l-4 border-red-500',
+                info: 'bg-blue-50 dark:bg-blue-900/20 text-blue-800 dark:text-blue-200 border-l-4 border-blue-500'
+            };
+            statusEl.className = `px-4 py-3 rounded-r-lg text-sm ${styles[type]}`;
+            statusEl.textContent = msg;
+        }
+        function hideStatus() { statusEl.classList.add('hidden'); }
+
+        function getIndent() {
+            const v = indentSel.value;
+            return v === '\\t' ? '\t' : parseInt(v, 10);
+        }
+
+        function locateError(text, msg) {
+            const m = msg.match(/position (\d+)/);
+            if (!m) return msg;
+            const pos = parseInt(m[1], 10);
+            const before = text.slice(0, pos);
+            const line = before.split('\n').length;
+            const col = pos - before.lastIndexOf('\n');
+            return `${msg.replace(/at position \d+/, '')} (第 ${line} 行，第 ${col} 欄)`;
+        }
+
+        function tryParse(text) {
+            try {
+                return { ok: true, value: JSON.parse(text) };
+            } catch (e) {
+                return { ok: false, error: locateError(text, e.message) };
+            }
+        }
+
+        function updateStats() {
+            inputStats.textContent = `${inputArea.value.length.toLocaleString()} chars`;
+            outputStats.textContent = `${outputArea.value.length.toLocaleString()} chars`;
+        }
+
+        document.getElementById('formatBtn').addEventListener('click', () => {
+            const text = inputArea.value.trim();
+            if (!text) { showStatus('info', '請先輸入 JSON'); return; }
+            const r = tryParse(text);
+            if (!r.ok) { showStatus('error', '⚠ JSON 解析錯誤：' + r.error); outputArea.value = ''; updateStats(); return; }
+            outputArea.value = JSON.stringify(r.value, null, getIndent());
+            showStatus('success', '✓ 美化完成');
+            renderTree(r.value);
+            updateStats();
+        });
+
+        document.getElementById('minifyBtn').addEventListener('click', () => {
+            const text = inputArea.value.trim();
+            if (!text) { showStatus('info', '請先輸入 JSON'); return; }
+            const r = tryParse(text);
+            if (!r.ok) { showStatus('error', '⚠ JSON 解析錯誤：' + r.error); return; }
+            outputArea.value = JSON.stringify(r.value);
+            showStatus('success', '✓ 壓縮完成');
+            renderTree(r.value);
+            updateStats();
+        });
+
+        document.getElementById('validateBtn').addEventListener('click', () => {
+            const text = inputArea.value.trim();
+            if (!text) { showStatus('info', '請先輸入 JSON'); return; }
+            const r = tryParse(text);
+            if (!r.ok) { showStatus('error', '⚠ 無效的 JSON：' + r.error); return; }
+            showStatus('success', '✓ JSON 格式有效');
+        });
+
+        document.getElementById('sampleBtn').addEventListener('click', () => {
+            inputArea.value = JSON.stringify({
+                name: "FeiFei Tools",
+                version: 1.0,
+                tools: ["JSON Formatter", "URL Encoder", "JWT Decoder"],
+                active: true,
+                meta: { author: "feifei", year: 2026, tags: null }
+            });
+            inputArea.dispatchEvent(new Event('input'));
+        });
+
+        document.getElementById('clearBtn').addEventListener('click', () => {
+            inputArea.value = '';
+            outputArea.value = '';
+            treeView.innerHTML = '';
+            hideStatus();
+            updateStats();
+        });
+
+        document.getElementById('copyBtn').addEventListener('click', async () => {
+            if (!outputArea.value) return;
+            try { await navigator.clipboard.writeText(outputArea.value); showToast('已複製'); }
+            catch { outputArea.select(); document.execCommand('copy'); showToast('已複製'); }
+        });
+
+        document.getElementById('downloadBtn').addEventListener('click', () => {
+            if (!outputArea.value) return;
+            const blob = new Blob([outputArea.value], { type: 'application/json;charset=utf-8' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url; a.download = 'formatted.json';
+            document.body.appendChild(a); a.click(); a.remove();
+            URL.revokeObjectURL(url);
+            showToast('已下載 .json');
+        });
+
+        // Tabs
+        function switchTab(toTree) {
+            if (toTree) {
+                outputArea.classList.add('hidden');
+                treeView.classList.remove('hidden');
+                tabTree.className = 'px-2.5 py-1 rounded-md text-xs font-medium bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300';
+                tabText.className = 'px-2.5 py-1 rounded-md text-xs font-medium text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700';
+            } else {
+                treeView.classList.add('hidden');
+                outputArea.classList.remove('hidden');
+                tabText.className = 'px-2.5 py-1 rounded-md text-xs font-medium bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300';
+                tabTree.className = 'px-2.5 py-1 rounded-md text-xs font-medium text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700';
+            }
+        }
+        tabText.addEventListener('click', () => switchTab(false));
+        tabTree.addEventListener('click', () => switchTab(true));
+
+        // Tree renderer
+        function escapeHtml(s) { return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
+        function renderValue(v) {
+            if (v === null) return '<span class="json-null">null</span>';
+            if (typeof v === 'boolean') return `<span class="json-bool">${v}</span>`;
+            if (typeof v === 'number') return `<span class="json-number">${v}</span>`;
+            if (typeof v === 'string') return `<span class="json-string">"${escapeHtml(v)}"</span>`;
+            if (Array.isArray(v)) {
+                if (v.length === 0) return '<span class="text-gray-500">[]</span>';
+                let html = `<details open><summary><span class="text-gray-500">[</span> <span class="text-gray-400 text-xs">${v.length} 項</span></summary><div class="tree-block">`;
+                v.forEach((item, i) => {
+                    html += `<div><span class="json-key">${i}</span><span class="text-gray-500">: </span>${renderValue(item)}</div>`;
+                });
+                html += '</div><span class="text-gray-500">]</span></details>';
+                return html;
+            }
+            if (typeof v === 'object') {
+                const keys = Object.keys(v);
+                if (keys.length === 0) return '<span class="text-gray-500">{}</span>';
+                let html = `<details open><summary><span class="text-gray-500">{</span> <span class="text-gray-400 text-xs">${keys.length} 項</span></summary><div class="tree-block">`;
+                keys.forEach(k => {
+                    html += `<div><span class="json-key">"${escapeHtml(k)}"</span><span class="text-gray-500">: </span>${renderValue(v[k])}</div>`;
+                });
+                html += '</div><span class="text-gray-500">}</span></details>';
+                return html;
+            }
+            return String(v);
+        }
+        function renderTree(v) {
+            treeView.innerHTML = renderValue(v);
+        }
+
+        inputArea.addEventListener('input', updateStats);
+        updateStats();
+    </script>
+</body>
+</html>

--- a/jwt-decoder.html
+++ b/jwt-decoder.html
@@ -1,0 +1,314 @@
+<!DOCTYPE html>
+<html lang="zh-TW" class="scroll-smooth">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <title>JWT 解碼器 - 線上免費 JWT Token 解析工具 | FeiFei Tools</title>
+    <meta name="description" content="免費線上 JWT 解碼器，貼上 Token 即可解析 Header、Payload、Signature，自動顯示簽發/過期時間，所有處理在瀏覽器中完成。">
+    <meta name="keywords" content="JWT解碼,JWT解析,JWT decoder,Token解析,線上JWT工具">
+    <meta name="author" content="FeiFei">
+    <link rel="canonical" href="https://tool.feifei.tw/jwt-decoder.html">
+
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://tool.feifei.tw/jwt-decoder.html">
+    <meta property="og:title" content="JWT 解碼器 | FeiFei Tools">
+    <meta property="og:description" content="免費線上 JWT Token 解析工具。">
+    <meta property="og:image" content="https://tool.feifei.tw/og-image.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="JWT 解碼器 | FeiFei Tools">
+    <meta name="twitter:description" content="免費線上 JWT Token 解析工具。">
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-B20B804DQS"></script>
+    <script>window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-B20B804DQS');</script>
+
+    <script>(function() { const saved = localStorage.getItem('theme'); const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches; if (saved === 'dark' || (!saved && prefersDark)) { document.documentElement.classList.add('dark'); } })();</script>
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>tailwind.config = { darkMode: 'class', theme: { extend: { fontFamily: { sans: ['Noto Sans TC', 'system-ui', 'sans-serif'] } } } }</script>
+
+    <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;700&display=swap" rel="stylesheet">
+
+    <script type="application/ld+json">{ "@context": "https://schema.org", "@type": "WebApplication", "name": "JWT 解碼器", "url": "https://tool.feifei.tw/jwt-decoder.html", "description": "JWT Token 解析工具", "applicationCategory": "DeveloperApplication", "operatingSystem": "Any", "offers": { "@type": "Offer", "price": "0", "priceCurrency": "TWD" } }</script>
+
+    <style>
+        .touch-target { min-height: 44px; min-width: 44px; }
+        .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }
+        .jwt-header { color: #dc2626; }
+        .jwt-payload { color: #7c3aed; }
+        .jwt-signature { color: #0891b2; }
+        .dark .jwt-header { color: #fca5a5; }
+        .dark .jwt-payload { color: #c4b5fd; }
+        .dark .jwt-signature { color: #67e8f9; }
+    </style>
+</head>
+<body class="font-sans bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 antialiased">
+
+    <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 bg-blue-600 text-white px-4 py-2 rounded-lg z-[100]">跳至主要內容</a>
+
+    <header class="hidden md:block sticky top-0 z-40 bg-white/80 dark:bg-gray-800/80 backdrop-blur-lg border-b border-gray-200 dark:border-gray-700">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex items-center justify-between h-16">
+                <a href="index.html" class="flex items-center gap-2 touch-target"><span class="text-2xl">🛠️</span><span class="font-bold text-xl">FeiFei Tools</span></a>
+                <nav class="flex items-center gap-1"><a href="index.html" class="px-3 py-2 rounded-lg text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 text-sm">首頁</a><span class="text-gray-300 dark:text-gray-600">/</span><span class="px-3 py-2 text-gray-900 dark:text-white font-medium text-sm">JWT 解碼器</span></nav>
+                <button id="theme-toggle-desktop" class="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors touch-target" aria-label="切換深色模式">
+                    <svg class="w-6 h-6 hidden dark:block text-yellow-400" fill="currentColor" viewBox="0 0 20 20"><path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+                    <svg class="w-6 h-6 block dark:hidden text-gray-600" fill="currentColor" viewBox="0 0 20 20"><path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/></svg>
+                </button>
+            </div>
+        </div>
+    </header>
+
+    <main id="main-content" class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-6 md:py-8 pb-24 md:pb-8">
+        <div class="mb-6">
+            <h1 class="text-2xl md:text-3xl font-bold mb-2 flex items-center gap-3"><span class="text-3xl">🔑</span>JWT 解碼器</h1>
+            <p class="text-gray-600 dark:text-gray-400">貼上 JWT Token 即可解析 Header、Payload、Signature，並自動轉換時間欄位</p>
+        </div>
+
+        <div class="space-y-6">
+            <!-- Input -->
+            <section class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden">
+                <div class="flex items-center justify-between px-4 py-2.5 border-b border-gray-200 dark:border-gray-700">
+                    <h2 class="text-sm font-semibold text-gray-700 dark:text-gray-200">JWT Token</h2>
+                    <div class="flex items-center gap-2">
+                        <button id="sampleBtn" class="px-2 py-1 text-xs text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md transition-colors">範例</button>
+                        <button id="clearBtn" class="px-2 py-1 text-xs text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md transition-colors">清除</button>
+                    </div>
+                </div>
+                <textarea id="tokenArea" spellcheck="false" placeholder="貼上 JWT Token，例如 eyJhbGciOiJIUzI1NiJ9..."
+                    class="w-full h-36 bg-white dark:bg-gray-800 border-0 px-4 py-3 font-mono text-sm leading-relaxed text-gray-800 dark:text-gray-100 resize-y focus:outline-none break-all"></textarea>
+                <div id="tokenPreview" class="hidden px-4 py-3 border-t border-gray-200 dark:border-gray-700 font-mono text-xs leading-relaxed break-all"></div>
+            </section>
+
+            <!-- Status -->
+            <div id="status" class="hidden px-4 py-3 rounded-r-lg text-sm"></div>
+
+            <!-- Three parts -->
+            <div class="grid grid-cols-1 lg:grid-cols-3 gap-4">
+                <section class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden">
+                    <div class="flex items-center justify-between px-4 py-2.5 border-b border-gray-200 dark:border-gray-700">
+                        <h3 class="text-sm font-semibold jwt-header flex items-center gap-2"><span class="w-2 h-2 rounded-full bg-red-500"></span>Header</h3>
+                        <button data-copy="headerOut" class="copy-btn px-2 py-1 text-xs text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md transition-colors">複製</button>
+                    </div>
+                    <pre id="headerOut" class="px-4 py-3 font-mono text-sm leading-relaxed text-gray-800 dark:text-gray-100 overflow-auto h-72 whitespace-pre-wrap">—</pre>
+                </section>
+
+                <section class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden">
+                    <div class="flex items-center justify-between px-4 py-2.5 border-b border-gray-200 dark:border-gray-700">
+                        <h3 class="text-sm font-semibold jwt-payload flex items-center gap-2"><span class="w-2 h-2 rounded-full bg-purple-500"></span>Payload</h3>
+                        <button data-copy="payloadOut" class="copy-btn px-2 py-1 text-xs text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md transition-colors">複製</button>
+                    </div>
+                    <pre id="payloadOut" class="px-4 py-3 font-mono text-sm leading-relaxed text-gray-800 dark:text-gray-100 overflow-auto h-72 whitespace-pre-wrap">—</pre>
+                </section>
+
+                <section class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden">
+                    <div class="flex items-center justify-between px-4 py-2.5 border-b border-gray-200 dark:border-gray-700">
+                        <h3 class="text-sm font-semibold jwt-signature flex items-center gap-2"><span class="w-2 h-2 rounded-full bg-cyan-500"></span>Signature</h3>
+                        <button data-copy="sigOut" class="copy-btn px-2 py-1 text-xs text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md transition-colors">複製</button>
+                    </div>
+                    <pre id="sigOut" class="px-4 py-3 font-mono text-xs leading-relaxed text-gray-800 dark:text-gray-100 overflow-auto h-72 whitespace-pre-wrap break-all">—</pre>
+                </section>
+            </div>
+
+            <!-- Claims summary -->
+            <section id="claimsBox" class="hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-5 md:p-6">
+                <h2 class="text-base font-semibold mb-4 text-gray-900 dark:text-white">時間與常見 Claims</h2>
+                <div id="claimsList" class="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm"></div>
+            </section>
+
+            <!-- Info -->
+            <div class="bg-blue-50 dark:bg-blue-900/20 rounded-xl p-4 text-sm text-blue-800 dark:text-blue-200">
+                <p class="font-medium mb-1">使用說明</p>
+                <ul class="list-disc list-inside space-y-1 text-blue-700 dark:text-blue-300">
+                    <li>JWT 由三段 Base64URL 字串組成，以「.」分隔：Header.Payload.Signature</li>
+                    <li>本工具僅做解碼，不會驗證簽章；簽章驗證需要對應的 secret / public key</li>
+                    <li>常見時間欄位：<code class="bg-white/40 dark:bg-black/20 px-1 rounded">iat</code>（簽發）、<code class="bg-white/40 dark:bg-black/20 px-1 rounded">exp</code>（過期）、<code class="bg-white/40 dark:bg-black/20 px-1 rounded">nbf</code>（生效）</li>
+                    <li>所有處理皆在瀏覽器本地完成，Token 不會送出</li>
+                </ul>
+            </div>
+        </div>
+    </main>
+
+    <nav class="md:hidden fixed bottom-0 left-0 right-0 z-50 bg-white/90 dark:bg-gray-800/90 backdrop-blur-lg border-t border-gray-200 dark:border-gray-700" style="padding-bottom: env(safe-area-inset-bottom, 0);">
+        <div class="grid grid-cols-5 h-16">
+            <a href="index.html" class="flex flex-col items-center justify-center text-gray-600 dark:text-gray-400 touch-target"><svg class="w-6 h-6" fill="currentColor" viewBox="0 0 20 20"><path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z"/></svg><span class="text-xs mt-0.5">首頁</span></a>
+            <a href="text-stats.html" class="flex flex-col items-center justify-center text-gray-600 dark:text-gray-400 touch-target"><svg class="w-6 h-6" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4z" clip-rule="evenodd"/></svg><span class="text-xs mt-0.5">文字</span></a>
+            <a href="pdf-to-png.html" class="flex flex-col items-center justify-center text-gray-600 dark:text-gray-400 touch-target"><svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg><span class="text-xs mt-0.5">圖片</span></a>
+            <a href="encry.html" class="flex flex-col items-center justify-center text-blue-600 dark:text-blue-400 touch-target"><svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/></svg><span class="text-xs mt-0.5 font-medium">開發</span></a>
+            <button id="theme-toggle-mobile" class="flex flex-col items-center justify-center text-gray-600 dark:text-gray-400 touch-target"><svg class="w-6 h-6 hidden dark:block" fill="currentColor" viewBox="0 0 20 20"><path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0z"/></svg><svg class="w-6 h-6 block dark:hidden" fill="currentColor" viewBox="0 0 20 20"><path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/></svg><span class="text-xs mt-0.5">主題</span></button>
+        </div>
+    </nav>
+
+    <div id="toast" class="fixed bottom-24 md:bottom-8 left-1/2 -translate-x-1/2 bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 px-4 py-2 rounded-lg shadow-lg transform transition-all duration-300 opacity-0 translate-y-4 pointer-events-none z-[60]"><span id="toast-message"></span></div>
+
+    <script>
+        function toggleTheme() { const isDark = document.documentElement.classList.toggle('dark'); localStorage.setItem('theme', isDark ? 'dark' : 'light'); }
+        document.getElementById('theme-toggle-desktop')?.addEventListener('click', toggleTheme);
+        document.getElementById('theme-toggle-mobile')?.addEventListener('click', toggleTheme);
+
+        function showToast(msg) {
+            const toast = document.getElementById('toast');
+            document.getElementById('toast-message').textContent = msg;
+            toast.classList.remove('opacity-0', 'translate-y-4', 'pointer-events-none');
+            toast.classList.add('opacity-100', 'translate-y-0');
+            setTimeout(() => { toast.classList.add('opacity-0', 'translate-y-4', 'pointer-events-none'); toast.classList.remove('opacity-100', 'translate-y-0'); }, 2000);
+        }
+
+        const tokenArea = document.getElementById('tokenArea');
+        const tokenPreview = document.getElementById('tokenPreview');
+        const headerOut = document.getElementById('headerOut');
+        const payloadOut = document.getElementById('payloadOut');
+        const sigOut = document.getElementById('sigOut');
+        const statusEl = document.getElementById('status');
+        const claimsBox = document.getElementById('claimsBox');
+        const claimsList = document.getElementById('claimsList');
+
+        function showStatus(type, msg) {
+            statusEl.classList.remove('hidden');
+            const styles = {
+                success: 'bg-green-50 dark:bg-green-900/20 text-green-800 dark:text-green-200 border-l-4 border-green-500',
+                error: 'bg-red-50 dark:bg-red-900/20 text-red-800 dark:text-red-200 border-l-4 border-red-500',
+                warn: 'bg-amber-50 dark:bg-amber-900/20 text-amber-800 dark:text-amber-200 border-l-4 border-amber-500'
+            };
+            statusEl.className = `px-4 py-3 rounded-r-lg text-sm ${styles[type]}`;
+            statusEl.innerHTML = msg;
+        }
+        function hideStatus() { statusEl.classList.add('hidden'); }
+
+        function b64urlDecode(str) {
+            str = str.replace(/-/g, '+').replace(/_/g, '/');
+            while (str.length % 4) str += '=';
+            const bin = atob(str);
+            try {
+                return decodeURIComponent(Array.from(bin).map(c => '%' + c.charCodeAt(0).toString(16).padStart(2, '0')).join(''));
+            } catch {
+                return bin;
+            }
+        }
+
+        function fmtTime(sec) {
+            try {
+                const d = new Date(sec * 1000);
+                if (isNaN(d.getTime())) return null;
+                return d.toLocaleString('zh-TW', { hour12: false });
+            } catch { return null; }
+        }
+        function timeFromNow(sec) {
+            const diff = sec - Math.floor(Date.now() / 1000);
+            const abs = Math.abs(diff);
+            const past = diff < 0;
+            const units = [
+                [86400, '天'], [3600, '小時'], [60, '分鐘'], [1, '秒']
+            ];
+            for (const [u, label] of units) {
+                if (abs >= u) {
+                    const n = Math.floor(abs / u);
+                    return past ? `${n} ${label}前` : `${n} ${label}後`;
+                }
+            }
+            return '剛剛';
+        }
+
+        function renderPreview(parts) {
+            tokenPreview.classList.remove('hidden');
+            tokenPreview.innerHTML = `<span class="jwt-header">${parts[0]}</span><span class="text-gray-400">.</span><span class="jwt-payload">${parts[1]}</span><span class="text-gray-400">.</span><span class="jwt-signature">${parts[2] || ''}</span>`;
+        }
+
+        function decode() {
+            const raw = tokenArea.value.trim();
+            if (!raw) {
+                hideStatus();
+                tokenPreview.classList.add('hidden');
+                headerOut.textContent = '—';
+                payloadOut.textContent = '—';
+                sigOut.textContent = '—';
+                claimsBox.classList.add('hidden');
+                return;
+            }
+            const parts = raw.split('.');
+            if (parts.length < 2 || parts.length > 3) {
+                showStatus('error', '⚠ 格式錯誤：JWT 應由 2~3 段以 「.」 分隔的字串組成');
+                return;
+            }
+            renderPreview(parts);
+            let header, payload;
+            try {
+                header = JSON.parse(b64urlDecode(parts[0]));
+            } catch (e) {
+                showStatus('error', '⚠ Header 解碼失敗：' + e.message);
+                return;
+            }
+            try {
+                payload = JSON.parse(b64urlDecode(parts[1]));
+            } catch (e) {
+                showStatus('error', '⚠ Payload 解碼失敗：' + e.message);
+                return;
+            }
+            headerOut.textContent = JSON.stringify(header, null, 2);
+            payloadOut.textContent = JSON.stringify(payload, null, 2);
+            sigOut.textContent = parts[2] || '(無)';
+
+            // Claims
+            renderClaims(payload);
+
+            // expiry check
+            const now = Math.floor(Date.now() / 1000);
+            if (typeof payload.exp === 'number') {
+                if (payload.exp < now) {
+                    showStatus('error', `⚠ Token 已過期（${timeFromNow(payload.exp)}）`);
+                } else if (typeof payload.nbf === 'number' && payload.nbf > now) {
+                    showStatus('warn', `⚠ Token 尚未生效（生效時間：${fmtTime(payload.nbf)}）`);
+                } else {
+                    showStatus('success', `✓ Token 解析成功，將於 ${timeFromNow(payload.exp)}過期`);
+                }
+            } else {
+                showStatus('success', '✓ Token 解析成功（未包含 exp 過期時間）');
+            }
+        }
+
+        function renderClaims(payload) {
+            const timeKeys = { iat: '簽發時間 (iat)', exp: '過期時間 (exp)', nbf: '生效時間 (nbf)', auth_time: '驗證時間 (auth_time)' };
+            const otherKeys = { iss: '簽發者 (iss)', sub: '主體 (sub)', aud: '對象 (aud)', jti: 'JWT ID (jti)' };
+            const items = [];
+            for (const [k, label] of Object.entries(timeKeys)) {
+                if (typeof payload[k] === 'number') {
+                    const t = fmtTime(payload[k]);
+                    items.push(`<div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-3 border border-gray-200 dark:border-gray-700"><div class="text-xs text-gray-500 dark:text-gray-400 mb-1">${label}</div><div class="font-mono text-sm">${t}</div><div class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">${timeFromNow(payload[k])}</div></div>`);
+                }
+            }
+            for (const [k, label] of Object.entries(otherKeys)) {
+                if (payload[k] !== undefined) {
+                    const v = typeof payload[k] === 'object' ? JSON.stringify(payload[k]) : String(payload[k]);
+                    items.push(`<div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-3 border border-gray-200 dark:border-gray-700"><div class="text-xs text-gray-500 dark:text-gray-400 mb-1">${label}</div><div class="font-mono text-sm break-all">${escapeHtml(v)}</div></div>`);
+                }
+            }
+            if (items.length === 0) { claimsBox.classList.add('hidden'); return; }
+            claimsList.innerHTML = items.join('');
+            claimsBox.classList.remove('hidden');
+        }
+
+        function escapeHtml(s) { return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
+
+        tokenArea.addEventListener('input', decode);
+
+        document.getElementById('clearBtn').addEventListener('click', () => { tokenArea.value = ''; decode(); });
+
+        document.getElementById('sampleBtn').addEventListener('click', () => {
+            // Sample JWT (HS256, dummy signature)
+            tokenArea.value = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkZlaUZlaSIsImlhdCI6MTUxNjIzOTAyMiwiZXhwIjoxOTk5OTk5OTk5fQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+            decode();
+        });
+
+        document.querySelectorAll('.copy-btn').forEach(btn => {
+            btn.addEventListener('click', async () => {
+                const id = btn.dataset.copy;
+                const text = document.getElementById(id).textContent;
+                if (!text || text === '—') return;
+                try { await navigator.clipboard.writeText(text); showToast('已複製'); }
+                catch { showToast('複製失敗'); }
+            });
+        });
+    </script>
+</body>
+</html>

--- a/qr-generator.html
+++ b/qr-generator.html
@@ -1,0 +1,280 @@
+<!DOCTYPE html>
+<html lang="zh-TW" class="scroll-smooth">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <title>QR Code 產生器 - 線上免費 QR 碼產生工具 | FeiFei Tools</title>
+    <meta name="description" content="免費線上 QR Code 產生器，支援文字、網址、自訂顏色與容錯等級，可下載 PNG 與 SVG，所有處理在瀏覽器中完成。">
+    <meta name="keywords" content="QR Code,QR碼,二維碼,QR Code產生器,線上QR工具">
+    <meta name="author" content="FeiFei">
+    <link rel="canonical" href="https://tool.feifei.tw/qr-generator.html">
+
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://tool.feifei.tw/qr-generator.html">
+    <meta property="og:title" content="QR Code 產生器 | FeiFei Tools">
+    <meta property="og:description" content="免費線上 QR Code 產生器，可下載 PNG 與 SVG。">
+    <meta property="og:image" content="https://tool.feifei.tw/og-image.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="QR Code 產生器 | FeiFei Tools">
+    <meta name="twitter:description" content="免費線上 QR Code 產生器。">
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-B20B804DQS"></script>
+    <script>window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-B20B804DQS');</script>
+
+    <script>(function() { const saved = localStorage.getItem('theme'); const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches; if (saved === 'dark' || (!saved && prefersDark)) { document.documentElement.classList.add('dark'); } })();</script>
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>tailwind.config = { darkMode: 'class', theme: { extend: { fontFamily: { sans: ['Noto Sans TC', 'system-ui', 'sans-serif'] } } } }</script>
+
+    <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;700&display=swap" rel="stylesheet">
+
+    <!-- QRCode -->
+    <script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.3/build/qrcode.min.js"></script>
+
+    <script type="application/ld+json">{ "@context": "https://schema.org", "@type": "WebApplication", "name": "QR Code 產生器", "url": "https://tool.feifei.tw/qr-generator.html", "description": "QR Code 產生工具", "applicationCategory": "UtilityApplication", "operatingSystem": "Any", "offers": { "@type": "Offer", "price": "0", "priceCurrency": "TWD" } }</script>
+
+    <style>.touch-target { min-height: 44px; min-width: 44px; } .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }</style>
+</head>
+<body class="font-sans bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 antialiased">
+
+    <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 bg-blue-600 text-white px-4 py-2 rounded-lg z-[100]">跳至主要內容</a>
+
+    <header class="hidden md:block sticky top-0 z-40 bg-white/80 dark:bg-gray-800/80 backdrop-blur-lg border-b border-gray-200 dark:border-gray-700">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex items-center justify-between h-16">
+                <a href="index.html" class="flex items-center gap-2 touch-target"><span class="text-2xl">🛠️</span><span class="font-bold text-xl">FeiFei Tools</span></a>
+                <nav class="flex items-center gap-1"><a href="index.html" class="px-3 py-2 rounded-lg text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 text-sm">首頁</a><span class="text-gray-300 dark:text-gray-600">/</span><span class="px-3 py-2 text-gray-900 dark:text-white font-medium text-sm">QR Code 產生器</span></nav>
+                <button id="theme-toggle-desktop" class="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors touch-target" aria-label="切換深色模式">
+                    <svg class="w-6 h-6 hidden dark:block text-yellow-400" fill="currentColor" viewBox="0 0 20 20"><path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+                    <svg class="w-6 h-6 block dark:hidden text-gray-600" fill="currentColor" viewBox="0 0 20 20"><path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/></svg>
+                </button>
+            </div>
+        </div>
+    </header>
+
+    <main id="main-content" class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-6 md:py-8 pb-24 md:pb-8">
+        <div class="mb-6">
+            <h1 class="text-2xl md:text-3xl font-bold mb-2 flex items-center gap-3"><span class="text-3xl">▦</span>QR Code 產生器</h1>
+            <p class="text-gray-600 dark:text-gray-400">輸入文字或網址即時產生 QR Code，支援自訂顏色、大小，並可下載 PNG / SVG</p>
+        </div>
+
+        <div class="grid grid-cols-1 lg:grid-cols-5 gap-4">
+            <!-- Settings -->
+            <section class="lg:col-span-3 bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-5 md:p-6 space-y-5">
+                <div>
+                    <label class="block text-sm font-medium mb-2">內容</label>
+                    <textarea id="textInput" spellcheck="false" placeholder="輸入文字或網址，例如 https://tool.feifei.tw"
+                        class="w-full h-32 px-3 py-2 bg-gray-50 dark:bg-gray-900 border border-gray-300 dark:border-gray-600 rounded-lg font-mono text-sm focus:outline-none focus:border-blue-500"></textarea>
+                </div>
+
+                <div class="grid grid-cols-2 gap-4">
+                    <div>
+                        <label class="block text-sm font-medium mb-2">容錯等級</label>
+                        <select id="ecLevel" class="w-full px-3 py-2 bg-gray-50 dark:bg-gray-900 border border-gray-300 dark:border-gray-600 rounded-lg text-sm focus:outline-none focus:border-blue-500">
+                            <option value="L">L（7%）</option>
+                            <option value="M" selected>M（15%）</option>
+                            <option value="Q">Q（25%）</option>
+                            <option value="H">H（30%）</option>
+                        </select>
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium mb-2">輸出尺寸</label>
+                        <select id="sizeSel" class="w-full px-3 py-2 bg-gray-50 dark:bg-gray-900 border border-gray-300 dark:border-gray-600 rounded-lg text-sm focus:outline-none focus:border-blue-500">
+                            <option value="256">256 px</option>
+                            <option value="512" selected>512 px</option>
+                            <option value="1024">1024 px</option>
+                            <option value="2048">2048 px</option>
+                        </select>
+                    </div>
+                </div>
+
+                <div class="grid grid-cols-2 gap-4">
+                    <div>
+                        <label class="block text-sm font-medium mb-2">前景色</label>
+                        <div class="flex items-center gap-2">
+                            <input type="color" id="fgColor" value="#000000" class="w-12 h-10 rounded-lg border border-gray-300 dark:border-gray-600 cursor-pointer bg-transparent">
+                            <input type="text" id="fgHex" value="#000000" class="flex-1 px-3 py-2 bg-gray-50 dark:bg-gray-900 border border-gray-300 dark:border-gray-600 rounded-lg font-mono text-sm focus:outline-none focus:border-blue-500">
+                        </div>
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium mb-2">背景色</label>
+                        <div class="flex items-center gap-2">
+                            <input type="color" id="bgColor" value="#ffffff" class="w-12 h-10 rounded-lg border border-gray-300 dark:border-gray-600 cursor-pointer bg-transparent">
+                            <input type="text" id="bgHex" value="#ffffff" class="flex-1 px-3 py-2 bg-gray-50 dark:bg-gray-900 border border-gray-300 dark:border-gray-600 rounded-lg font-mono text-sm focus:outline-none focus:border-blue-500">
+                        </div>
+                    </div>
+                </div>
+
+                <div>
+                    <label class="block text-sm font-medium mb-2">邊框寬度（modules）</label>
+                    <div class="flex items-center gap-3">
+                        <input type="range" id="marginRange" min="0" max="8" value="2" class="flex-1 accent-blue-600">
+                        <span id="marginVal" class="font-mono text-sm w-8 text-right">2</span>
+                    </div>
+                </div>
+
+                <div id="status" class="hidden px-3 py-2 rounded-lg text-sm"></div>
+            </section>
+
+            <!-- Preview -->
+            <section class="lg:col-span-2 bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-5 md:p-6 flex flex-col">
+                <h2 class="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-3">預覽</h2>
+                <div class="flex-1 flex items-center justify-center bg-gray-50 dark:bg-gray-900 rounded-lg p-4 min-h-[280px]">
+                    <canvas id="qrCanvas" class="max-w-full max-h-[400px] hidden" style="image-rendering: pixelated"></canvas>
+                    <div id="placeholder" class="text-center text-gray-400 dark:text-gray-500">
+                        <svg class="w-16 h-16 mx-auto mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 4h6v6H4V4zm10 0h6v6h-6V4zM4 14h6v6H4v-6zm10 0h2v2h-2v-2zm4 0h2v2h-2v-2zm-4 4h2v2h-2v-2zm4 0h2v2h-2v-2z"/></svg>
+                        <p class="text-sm">輸入內容後將顯示 QR Code</p>
+                    </div>
+                </div>
+                <div class="flex flex-col gap-2 mt-4">
+                    <button id="downloadPngBtn" class="inline-flex items-center justify-center gap-2 px-4 py-2.5 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-300 dark:disabled:bg-gray-700 disabled:cursor-not-allowed text-white text-sm font-medium rounded-lg transition-colors touch-target" disabled>
+                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/></svg>
+                        下載 PNG
+                    </button>
+                    <button id="downloadSvgBtn" class="inline-flex items-center justify-center gap-2 px-4 py-2.5 bg-white hover:bg-gray-50 dark:bg-gray-700 dark:hover:bg-gray-600 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 disabled:opacity-50 disabled:cursor-not-allowed text-sm font-medium rounded-lg transition-colors touch-target" disabled>
+                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/></svg>
+                        下載 SVG
+                    </button>
+                </div>
+            </section>
+        </div>
+
+        <div class="bg-blue-50 dark:bg-blue-900/20 rounded-xl p-4 text-sm text-blue-800 dark:text-blue-200 mt-4">
+            <p class="font-medium mb-1">使用說明</p>
+            <ul class="list-disc list-inside space-y-1 text-blue-700 dark:text-blue-300">
+                <li>容錯等級越高，QR Code 越「重」但可容忍更多遮蔽（H 級可容忍約 30% 損毀）</li>
+                <li>若要列印或印刷，建議下載 SVG 以保留無限放大畫質</li>
+                <li>內容變更後會即時重繪，所有產生都在瀏覽器本地完成</li>
+            </ul>
+        </div>
+    </main>
+
+    <nav class="md:hidden fixed bottom-0 left-0 right-0 z-50 bg-white/90 dark:bg-gray-800/90 backdrop-blur-lg border-t border-gray-200 dark:border-gray-700" style="padding-bottom: env(safe-area-inset-bottom, 0);">
+        <div class="grid grid-cols-5 h-16">
+            <a href="index.html" class="flex flex-col items-center justify-center text-gray-600 dark:text-gray-400 touch-target"><svg class="w-6 h-6" fill="currentColor" viewBox="0 0 20 20"><path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z"/></svg><span class="text-xs mt-0.5">首頁</span></a>
+            <a href="text-stats.html" class="flex flex-col items-center justify-center text-gray-600 dark:text-gray-400 touch-target"><svg class="w-6 h-6" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4z" clip-rule="evenodd"/></svg><span class="text-xs mt-0.5">文字</span></a>
+            <a href="pdf-to-png.html" class="flex flex-col items-center justify-center text-gray-600 dark:text-gray-400 touch-target"><svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg><span class="text-xs mt-0.5">圖片</span></a>
+            <a href="encry.html" class="flex flex-col items-center justify-center text-blue-600 dark:text-blue-400 touch-target"><svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/></svg><span class="text-xs mt-0.5 font-medium">開發</span></a>
+            <button id="theme-toggle-mobile" class="flex flex-col items-center justify-center text-gray-600 dark:text-gray-400 touch-target"><svg class="w-6 h-6 hidden dark:block" fill="currentColor" viewBox="0 0 20 20"><path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0z"/></svg><svg class="w-6 h-6 block dark:hidden" fill="currentColor" viewBox="0 0 20 20"><path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/></svg><span class="text-xs mt-0.5">主題</span></button>
+        </div>
+    </nav>
+
+    <div id="toast" class="fixed bottom-24 md:bottom-8 left-1/2 -translate-x-1/2 bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 px-4 py-2 rounded-lg shadow-lg transform transition-all duration-300 opacity-0 translate-y-4 pointer-events-none z-[60]"><span id="toast-message"></span></div>
+
+    <script>
+        function toggleTheme() { const isDark = document.documentElement.classList.toggle('dark'); localStorage.setItem('theme', isDark ? 'dark' : 'light'); }
+        document.getElementById('theme-toggle-desktop')?.addEventListener('click', toggleTheme);
+        document.getElementById('theme-toggle-mobile')?.addEventListener('click', toggleTheme);
+
+        function showToast(msg) {
+            const toast = document.getElementById('toast');
+            document.getElementById('toast-message').textContent = msg;
+            toast.classList.remove('opacity-0', 'translate-y-4', 'pointer-events-none');
+            toast.classList.add('opacity-100', 'translate-y-0');
+            setTimeout(() => { toast.classList.add('opacity-0', 'translate-y-4', 'pointer-events-none'); toast.classList.remove('opacity-100', 'translate-y-0'); }, 2000);
+        }
+
+        const textInput = document.getElementById('textInput');
+        const ecLevel = document.getElementById('ecLevel');
+        const sizeSel = document.getElementById('sizeSel');
+        const fgColor = document.getElementById('fgColor');
+        const bgColor = document.getElementById('bgColor');
+        const fgHex = document.getElementById('fgHex');
+        const bgHex = document.getElementById('bgHex');
+        const marginRange = document.getElementById('marginRange');
+        const marginVal = document.getElementById('marginVal');
+        const qrCanvas = document.getElementById('qrCanvas');
+        const placeholder = document.getElementById('placeholder');
+        const statusEl = document.getElementById('status');
+        const downloadPngBtn = document.getElementById('downloadPngBtn');
+        const downloadSvgBtn = document.getElementById('downloadSvgBtn');
+
+        function showError(msg) {
+            statusEl.classList.remove('hidden');
+            statusEl.className = 'px-3 py-2 rounded-lg text-sm bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-200 border border-red-200 dark:border-red-800';
+            statusEl.textContent = '⚠ ' + msg;
+        }
+        function hideStatus() { statusEl.classList.add('hidden'); }
+
+        function syncColor(color, hex) {
+            color.addEventListener('input', () => { hex.value = color.value; render(); });
+            hex.addEventListener('input', () => {
+                const v = hex.value.trim();
+                if (/^#[0-9a-fA-F]{6}$/.test(v)) { color.value = v; render(); }
+            });
+        }
+        syncColor(fgColor, fgHex);
+        syncColor(bgColor, bgHex);
+
+        marginRange.addEventListener('input', () => { marginVal.textContent = marginRange.value; render(); });
+        [textInput, ecLevel, sizeSel].forEach(el => el.addEventListener('input', render));
+
+        async function render() {
+            const text = textInput.value;
+            if (!text) {
+                qrCanvas.classList.add('hidden');
+                placeholder.classList.remove('hidden');
+                downloadPngBtn.disabled = true;
+                downloadSvgBtn.disabled = true;
+                hideStatus();
+                return;
+            }
+            const opts = {
+                errorCorrectionLevel: ecLevel.value,
+                width: parseInt(sizeSel.value, 10),
+                margin: parseInt(marginRange.value, 10),
+                color: { dark: fgColor.value, light: bgColor.value }
+            };
+            try {
+                await QRCode.toCanvas(qrCanvas, text, opts);
+                qrCanvas.classList.remove('hidden');
+                placeholder.classList.add('hidden');
+                downloadPngBtn.disabled = false;
+                downloadSvgBtn.disabled = false;
+                hideStatus();
+            } catch (e) {
+                showError(e.message || '產生失敗');
+                qrCanvas.classList.add('hidden');
+                placeholder.classList.remove('hidden');
+                downloadPngBtn.disabled = true;
+                downloadSvgBtn.disabled = true;
+            }
+        }
+
+        function safeFilename() {
+            const text = textInput.value.trim();
+            const base = text.replace(/^https?:\/\//, '').replace(/[^a-zA-Z0-9_\-]/g, '_').slice(0, 30) || 'qrcode';
+            return base;
+        }
+
+        downloadPngBtn.addEventListener('click', () => {
+            const url = qrCanvas.toDataURL('image/png');
+            const a = document.createElement('a');
+            a.href = url; a.download = `${safeFilename()}.png`;
+            document.body.appendChild(a); a.click(); a.remove();
+            showToast('已下載 PNG');
+        });
+
+        downloadSvgBtn.addEventListener('click', async () => {
+            const opts = {
+                errorCorrectionLevel: ecLevel.value,
+                margin: parseInt(marginRange.value, 10),
+                color: { dark: fgColor.value, light: bgColor.value },
+                width: parseInt(sizeSel.value, 10)
+            };
+            try {
+                const svg = await QRCode.toString(textInput.value, { ...opts, type: 'svg' });
+                const blob = new Blob([svg], { type: 'image/svg+xml;charset=utf-8' });
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.href = url; a.download = `${safeFilename()}.svg`;
+                document.body.appendChild(a); a.click(); a.remove();
+                URL.revokeObjectURL(url);
+                showToast('已下載 SVG');
+            } catch (e) { showError(e.message || '產生 SVG 失敗'); }
+        });
+    </script>
+</body>
+</html>

--- a/url-encode.html
+++ b/url-encode.html
@@ -1,0 +1,283 @@
+<!DOCTYPE html>
+<html lang="zh-TW" class="scroll-smooth">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <title>URL 編解碼工具 - 線上免費 URL Encode/Decode | FeiFei Tools</title>
+    <meta name="description" content="免費線上 URL 編解碼工具，支援 encodeURIComponent / encodeURI、即時編解碼、查詢字串拆解，所有處理在瀏覽器中完成。">
+    <meta name="keywords" content="URL編碼,URL解碼,URL encode,URL decode,線上URL工具,encodeURIComponent">
+    <meta name="author" content="FeiFei">
+    <link rel="canonical" href="https://tool.feifei.tw/url-encode.html">
+
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://tool.feifei.tw/url-encode.html">
+    <meta property="og:title" content="URL 編解碼工具 | FeiFei Tools">
+    <meta property="og:description" content="免費線上 URL 編解碼與查詢字串拆解工具。">
+    <meta property="og:image" content="https://tool.feifei.tw/og-image.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="URL 編解碼工具 | FeiFei Tools">
+    <meta name="twitter:description" content="免費線上 URL 編解碼工具。">
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-B20B804DQS"></script>
+    <script>window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-B20B804DQS');</script>
+
+    <script>(function() { const saved = localStorage.getItem('theme'); const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches; if (saved === 'dark' || (!saved && prefersDark)) { document.documentElement.classList.add('dark'); } })();</script>
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>tailwind.config = { darkMode: 'class', theme: { extend: { fontFamily: { sans: ['Noto Sans TC', 'system-ui', 'sans-serif'] } } } }</script>
+
+    <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;700&display=swap" rel="stylesheet">
+
+    <script type="application/ld+json">{ "@context": "https://schema.org", "@type": "WebApplication", "name": "URL 編解碼工具", "url": "https://tool.feifei.tw/url-encode.html", "description": "URL Encode / Decode 工具", "applicationCategory": "DeveloperApplication", "operatingSystem": "Any", "offers": { "@type": "Offer", "price": "0", "priceCurrency": "TWD" } }</script>
+
+    <style>.touch-target { min-height: 44px; min-width: 44px; } .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }</style>
+</head>
+<body class="font-sans bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 antialiased">
+
+    <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 bg-blue-600 text-white px-4 py-2 rounded-lg z-[100]">跳至主要內容</a>
+
+    <header class="hidden md:block sticky top-0 z-40 bg-white/80 dark:bg-gray-800/80 backdrop-blur-lg border-b border-gray-200 dark:border-gray-700">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex items-center justify-between h-16">
+                <a href="index.html" class="flex items-center gap-2 touch-target"><span class="text-2xl">🛠️</span><span class="font-bold text-xl">FeiFei Tools</span></a>
+                <nav class="flex items-center gap-1"><a href="index.html" class="px-3 py-2 rounded-lg text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 text-sm">首頁</a><span class="text-gray-300 dark:text-gray-600">/</span><span class="px-3 py-2 text-gray-900 dark:text-white font-medium text-sm">URL 編解碼</span></nav>
+                <button id="theme-toggle-desktop" class="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors touch-target" aria-label="切換深色模式">
+                    <svg class="w-6 h-6 hidden dark:block text-yellow-400" fill="currentColor" viewBox="0 0 20 20"><path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+                    <svg class="w-6 h-6 block dark:hidden text-gray-600" fill="currentColor" viewBox="0 0 20 20"><path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/></svg>
+                </button>
+            </div>
+        </div>
+    </header>
+
+    <main id="main-content" class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-6 md:py-8 pb-24 md:pb-8">
+        <div class="mb-6">
+            <h1 class="text-2xl md:text-3xl font-bold mb-2 flex items-center gap-3"><span class="text-3xl">🔗</span>URL 編解碼工具</h1>
+            <p class="text-gray-600 dark:text-gray-400">URL Encode / Decode、查詢字串拆解，即時雙向同步</p>
+        </div>
+
+        <div class="space-y-6">
+            <!-- Mode toggle -->
+            <div class="flex flex-wrap items-center gap-3">
+                <div class="inline-flex bg-gray-200 dark:bg-gray-700 rounded-lg p-1">
+                    <button id="modeEncode" class="px-4 py-1.5 text-sm font-medium rounded-md bg-white dark:bg-gray-900 shadow-sm text-blue-600 dark:text-blue-400">編碼</button>
+                    <button id="modeDecode" class="px-4 py-1.5 text-sm font-medium rounded-md text-gray-600 dark:text-gray-300">解碼</button>
+                </div>
+
+                <div class="flex items-center gap-2">
+                    <label for="funcSel" class="text-sm text-gray-600 dark:text-gray-400">函式</label>
+                    <select id="funcSel" class="px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg text-sm focus:outline-none focus:border-blue-500">
+                        <option value="component">encodeURIComponent（推薦）</option>
+                        <option value="uri">encodeURI（保留 :/?&=）</option>
+                    </select>
+                </div>
+
+                <div class="ml-auto flex items-center gap-2">
+                    <button id="swapBtn" class="inline-flex items-center gap-2 px-3 py-2 bg-white hover:bg-gray-50 dark:bg-gray-800 dark:hover:bg-gray-700 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 text-sm font-medium rounded-lg transition-colors touch-target">⇅ 對調</button>
+                    <button id="clearBtn" class="inline-flex items-center gap-2 px-3 py-2 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 text-sm font-medium rounded-lg transition-colors touch-target">清除</button>
+                </div>
+            </div>
+
+            <!-- Status -->
+            <div id="status" class="hidden px-4 py-3 rounded-r-lg text-sm"></div>
+
+            <!-- Input/Output -->
+            <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+                <section class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden">
+                    <div class="flex items-center justify-between px-4 py-2.5 border-b border-gray-200 dark:border-gray-700">
+                        <h2 id="leftTitle" class="text-sm font-semibold text-gray-700 dark:text-gray-200">原始文字</h2>
+                        <button id="copyInputBtn" class="px-2 py-1 text-xs text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md transition-colors">複製</button>
+                    </div>
+                    <textarea id="inputArea" spellcheck="false" placeholder="輸入要編碼的文字 / 網址…"
+                        class="w-full h-72 bg-white dark:bg-gray-800 border-0 px-4 py-3 font-mono text-sm leading-relaxed text-gray-800 dark:text-gray-100 resize-y focus:outline-none"></textarea>
+                </section>
+
+                <section class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden">
+                    <div class="flex items-center justify-between px-4 py-2.5 border-b border-gray-200 dark:border-gray-700">
+                        <h2 id="rightTitle" class="text-sm font-semibold text-gray-700 dark:text-gray-200">編碼結果</h2>
+                        <button id="copyOutputBtn" class="px-2 py-1 text-xs text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md transition-colors">複製</button>
+                    </div>
+                    <textarea id="outputArea" spellcheck="false" placeholder="結果將顯示於此…"
+                        class="w-full h-72 bg-white dark:bg-gray-800 border-0 px-4 py-3 font-mono text-sm leading-relaxed text-gray-800 dark:text-gray-100 resize-y focus:outline-none"></textarea>
+                </section>
+            </div>
+
+            <!-- Query string parser -->
+            <section class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-5 md:p-6">
+                <div class="flex items-center justify-between mb-4 flex-wrap gap-2">
+                    <div>
+                        <h2 class="text-base font-semibold text-gray-900 dark:text-white">查詢字串拆解</h2>
+                        <p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">自動拆解網址中的參數（自動 decode）</p>
+                    </div>
+                    <button id="parseBtn" class="inline-flex items-center gap-2 px-3 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg transition-colors">解析網址</button>
+                </div>
+                <div id="paramsTable" class="text-sm text-gray-500 dark:text-gray-400 italic">尚未解析，請點上方「解析網址」</div>
+            </section>
+
+            <!-- Info -->
+            <div class="bg-blue-50 dark:bg-blue-900/20 rounded-xl p-4 text-sm text-blue-800 dark:text-blue-200">
+                <p class="font-medium mb-1">使用說明</p>
+                <ul class="list-disc list-inside space-y-1 text-blue-700 dark:text-blue-300">
+                    <li><code class="bg-white/40 dark:bg-black/20 px-1 rounded">encodeURIComponent</code>：編碼所有特殊字元，包含 <code class="bg-white/40 dark:bg-black/20 px-1 rounded">:/?&amp;=</code>，適合放在參數值</li>
+                    <li><code class="bg-white/40 dark:bg-black/20 px-1 rounded">encodeURI</code>：保留 URL 結構字元，適合編碼整個網址</li>
+                    <li>輸入後即時雙向同步轉換，無需手動點按鈕</li>
+                </ul>
+            </div>
+        </div>
+    </main>
+
+    <nav class="md:hidden fixed bottom-0 left-0 right-0 z-50 bg-white/90 dark:bg-gray-800/90 backdrop-blur-lg border-t border-gray-200 dark:border-gray-700" style="padding-bottom: env(safe-area-inset-bottom, 0);">
+        <div class="grid grid-cols-5 h-16">
+            <a href="index.html" class="flex flex-col items-center justify-center text-gray-600 dark:text-gray-400 touch-target"><svg class="w-6 h-6" fill="currentColor" viewBox="0 0 20 20"><path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z"/></svg><span class="text-xs mt-0.5">首頁</span></a>
+            <a href="text-stats.html" class="flex flex-col items-center justify-center text-gray-600 dark:text-gray-400 touch-target"><svg class="w-6 h-6" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4z" clip-rule="evenodd"/></svg><span class="text-xs mt-0.5">文字</span></a>
+            <a href="pdf-to-png.html" class="flex flex-col items-center justify-center text-gray-600 dark:text-gray-400 touch-target"><svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg><span class="text-xs mt-0.5">圖片</span></a>
+            <a href="encry.html" class="flex flex-col items-center justify-center text-blue-600 dark:text-blue-400 touch-target"><svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/></svg><span class="text-xs mt-0.5 font-medium">開發</span></a>
+            <button id="theme-toggle-mobile" class="flex flex-col items-center justify-center text-gray-600 dark:text-gray-400 touch-target"><svg class="w-6 h-6 hidden dark:block" fill="currentColor" viewBox="0 0 20 20"><path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0z"/></svg><svg class="w-6 h-6 block dark:hidden" fill="currentColor" viewBox="0 0 20 20"><path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/></svg><span class="text-xs mt-0.5">主題</span></button>
+        </div>
+    </nav>
+
+    <div id="toast" class="fixed bottom-24 md:bottom-8 left-1/2 -translate-x-1/2 bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 px-4 py-2 rounded-lg shadow-lg transform transition-all duration-300 opacity-0 translate-y-4 pointer-events-none z-[60]"><span id="toast-message"></span></div>
+
+    <script>
+        function toggleTheme() { const isDark = document.documentElement.classList.toggle('dark'); localStorage.setItem('theme', isDark ? 'dark' : 'light'); }
+        document.getElementById('theme-toggle-desktop')?.addEventListener('click', toggleTheme);
+        document.getElementById('theme-toggle-mobile')?.addEventListener('click', toggleTheme);
+
+        function showToast(msg) {
+            const toast = document.getElementById('toast');
+            document.getElementById('toast-message').textContent = msg;
+            toast.classList.remove('opacity-0', 'translate-y-4', 'pointer-events-none');
+            toast.classList.add('opacity-100', 'translate-y-0');
+            setTimeout(() => { toast.classList.add('opacity-0', 'translate-y-4', 'pointer-events-none'); toast.classList.remove('opacity-100', 'translate-y-0'); }, 2000);
+        }
+
+        const inputArea = document.getElementById('inputArea');
+        const outputArea = document.getElementById('outputArea');
+        const modeEncode = document.getElementById('modeEncode');
+        const modeDecode = document.getElementById('modeDecode');
+        const funcSel = document.getElementById('funcSel');
+        const leftTitle = document.getElementById('leftTitle');
+        const rightTitle = document.getElementById('rightTitle');
+        const statusEl = document.getElementById('status');
+        const paramsTable = document.getElementById('paramsTable');
+
+        let mode = 'encode';
+
+        function showError(msg) {
+            statusEl.classList.remove('hidden');
+            statusEl.className = 'px-4 py-3 rounded-r-lg text-sm bg-red-50 dark:bg-red-900/20 text-red-800 dark:text-red-200 border-l-4 border-red-500';
+            statusEl.textContent = '⚠ ' + msg;
+        }
+        function hideStatus() { statusEl.classList.add('hidden'); }
+
+        function setMode(m) {
+            mode = m;
+            const active = 'px-4 py-1.5 text-sm font-medium rounded-md bg-white dark:bg-gray-900 shadow-sm text-blue-600 dark:text-blue-400';
+            const inactive = 'px-4 py-1.5 text-sm font-medium rounded-md text-gray-600 dark:text-gray-300';
+            if (m === 'encode') {
+                modeEncode.className = active;
+                modeDecode.className = inactive;
+                leftTitle.textContent = '原始文字';
+                rightTitle.textContent = '編碼結果';
+                inputArea.placeholder = '輸入要編碼的文字 / 網址…';
+            } else {
+                modeEncode.className = inactive;
+                modeDecode.className = active;
+                leftTitle.textContent = '已編碼文字';
+                rightTitle.textContent = '解碼結果';
+                inputArea.placeholder = '輸入要解碼的字串…';
+            }
+            triggerFromInput();
+        }
+        modeEncode.addEventListener('click', () => setMode('encode'));
+        modeDecode.addEventListener('click', () => setMode('decode'));
+
+        function encodeText(text) {
+            return funcSel.value === 'uri' ? encodeURI(text) : encodeURIComponent(text);
+        }
+        function decodeText(text) {
+            try { return funcSel.value === 'uri' ? decodeURI(text) : decodeURIComponent(text); }
+            catch (e) { throw new Error('無法解碼：包含非法的 % 序列'); }
+        }
+
+        function triggerFromInput() {
+            hideStatus();
+            const text = inputArea.value;
+            if (!text) { outputArea.value = ''; return; }
+            try {
+                outputArea.value = mode === 'encode' ? encodeText(text) : decodeText(text);
+            } catch (e) {
+                showError(e.message);
+                outputArea.value = '';
+            }
+        }
+        function triggerFromOutput() {
+            hideStatus();
+            const text = outputArea.value;
+            if (!text) { inputArea.value = ''; return; }
+            try {
+                inputArea.value = mode === 'encode' ? decodeText(text) : encodeText(text);
+            } catch (e) {
+                showError(e.message);
+                inputArea.value = '';
+            }
+        }
+        inputArea.addEventListener('input', triggerFromInput);
+        outputArea.addEventListener('input', triggerFromOutput);
+        funcSel.addEventListener('change', triggerFromInput);
+
+        document.getElementById('swapBtn').addEventListener('click', () => {
+            const t = inputArea.value;
+            inputArea.value = outputArea.value;
+            outputArea.value = t;
+            triggerFromInput();
+        });
+
+        document.getElementById('clearBtn').addEventListener('click', () => {
+            inputArea.value = ''; outputArea.value = '';
+            hideStatus();
+            paramsTable.innerHTML = '<span class="italic">尚未解析，請點上方「解析網址」</span>';
+        });
+
+        async function doCopy(text) {
+            if (!text) return;
+            try { await navigator.clipboard.writeText(text); showToast('已複製'); }
+            catch { showToast('複製失敗'); }
+        }
+        document.getElementById('copyInputBtn').addEventListener('click', () => doCopy(inputArea.value));
+        document.getElementById('copyOutputBtn').addEventListener('click', () => doCopy(outputArea.value));
+
+        // Query parser
+        document.getElementById('parseBtn').addEventListener('click', () => {
+            const text = (inputArea.value || outputArea.value).trim();
+            if (!text) { paramsTable.innerHTML = '<span class="text-red-600 dark:text-red-400">請先在左右欄輸入網址</span>'; return; }
+            let qs = text;
+            try {
+                const u = new URL(text);
+                qs = u.search.replace(/^\?/, '') + (u.hash ? ' #' + u.hash.slice(1) : '');
+                renderParamsFromURL(u);
+                return;
+            } catch {}
+            const params = new URLSearchParams(qs.replace(/^\?/, ''));
+            renderParams(params);
+        });
+        function escapeHtml(s) { return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
+        function renderParamsFromURL(u) {
+            let html = `<div class="space-y-2 mb-4 text-xs"><div class="grid grid-cols-[80px_1fr] gap-2"><span class="text-gray-500 dark:text-gray-400">protocol</span><span class="font-mono break-all">${escapeHtml(u.protocol)}</span></div><div class="grid grid-cols-[80px_1fr] gap-2"><span class="text-gray-500 dark:text-gray-400">host</span><span class="font-mono break-all">${escapeHtml(u.host)}</span></div><div class="grid grid-cols-[80px_1fr] gap-2"><span class="text-gray-500 dark:text-gray-400">pathname</span><span class="font-mono break-all">${escapeHtml(u.pathname)}</span></div>${u.hash ? `<div class="grid grid-cols-[80px_1fr] gap-2"><span class="text-gray-500 dark:text-gray-400">hash</span><span class="font-mono break-all">${escapeHtml(u.hash)}</span></div>` : ''}</div>`;
+            paramsTable.innerHTML = html + renderParamsHtml(u.searchParams);
+        }
+        function renderParams(params) { paramsTable.innerHTML = renderParamsHtml(params); }
+        function renderParamsHtml(params) {
+            const entries = [...params.entries()];
+            if (entries.length === 0) return '<div class="text-gray-500 italic">沒有查詢參數</div>';
+            let rows = entries.map(([k, v]) => `
+                <tr class="border-b border-gray-100 dark:border-gray-700 last:border-0">
+                    <td class="py-2 pr-4 font-mono text-blue-600 dark:text-blue-400 break-all">${escapeHtml(k)}</td>
+                    <td class="py-2 font-mono text-gray-700 dark:text-gray-200 break-all">${escapeHtml(v)}</td>
+                </tr>`).join('');
+            return `<div class="overflow-x-auto"><table class="w-full text-sm"><thead><tr class="text-xs uppercase tracking-wider text-gray-500 dark:text-gray-400 border-b border-gray-200 dark:border-gray-700"><th class="py-2 pr-4 text-left">Key</th><th class="py-2 text-left">Value</th></tr></thead><tbody>${rows}</tbody></table></div>`;
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

本分支累積了 4 個 commits，涵蓋 6 個新工具與 1 個樣式統一：

### 新增工具（6 個）

**圖片工具**
- 📄 **PDF 轉 TXT 純文字擷取**（`pdf-to-txt.html`）— 將 PDF 解析為純文字，支援多頁複製與下載
- 🖼️ **圖片轉 Base64**（`image-to-base64.html`）— 圖片轉 Data URL，可重編碼為 PNG/JPEG/WebP，輸出 Data URL / 純 Base64 / `<img>` / CSS background

**開發者工具**
- `{ }` **JSON 格式化**（`json-formatter.html`）— 美化 / 壓縮 / 驗證 / 樹狀檢視，自動標示錯誤行列
- 🔗 **URL 編解碼**（`url-encode.html`）— `encodeURIComponent` / `encodeURI` 雙向即時轉換，查詢字串拆解
- 🔑 **JWT 解碼器**（`jwt-decoder.html`）— 三段解析 Header / Payload / Signature，自動轉換 `iat`/`exp`/`nbf` 時間
- ▦ **QR Code 產生器**（`qr-generator.html`）— 自訂顏色 / 容錯等級 / 尺寸，下載 PNG 與 SVG

### 樣式統一
- 重構 **Word 批次取代工具**（`word-replace.html`）改用統一 Tailwind 樣式

### 自動目錄腳本同步
- 將 6 個新工具註冊至 `.github/scripts/update_toc.py` 的 `TOOL_CATEGORIES` / `TOOL_ICONS` / `TOOL_KEYWORDS` 三個字典，避免 workflow 重新生成時被洗掉

### 共同特性
- 純前端執行，所有處理在瀏覽器本地完成，無外部 API
- 統一深色模式、桌機 sticky header、手機底部導覽、Toast 通知
- 完整 SEO（canonical / Open Graph / Twitter Card / JSON-LD）
- GA 追蹤碼一致

## Test plan

- [ ] 開啟 `index.html` 確認 6 張新卡片正常顯示在對應分類
- [ ] 測試 JSON 格式化：貼上 JSON 驗證美化 / 壓縮 / 錯誤訊息行列定位
- [ ] 測試 URL 編解碼：雙向同步、查詢字串拆解、`encodeURI` vs `encodeURIComponent`
- [ ] 測試 JWT 解碼器：貼上範例 Token 確認三段顯示與時間欄位轉換
- [ ] 測試 QR Code 產生器：產生 QR、下載 PNG 與 SVG
- [ ] 測試圖片轉 Base64：拖曳上傳、切換格式、4 種輸出片段切換
- [ ] 測試 PDF 轉 TXT：上傳多頁 PDF 確認文字擷取
- [ ] 測試 Word 批次取代工具樣式是否與其他工具一致
- [ ] 深色模式切換是否在所有新頁面正常運作
- [ ] 手機版底部導覽顯示與點擊區域

---
_Generated by [Claude Code](https://claude.ai/code/session_01W7v36sbeFqRfHjJ5mseS7g)_