### PR TITLE
PNG 轉 PDF：新增可選輸出檔案大小

### DIFF
--- a/png-to-pdf.html
+++ b/png-to-pdf.html
@@ -78,6 +78,7 @@
                     <svg class="w-12 h-12 mx-auto text-gray-400 dark:text-gray-500 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg>
                     <p class="text-lg font-medium mb-1">選擇圖片</p>
                     <p class="text-sm text-gray-500 dark:text-gray-400">或拖放圖片到此處（支援 PNG / JPEG / WebP，可多選）</p>
+                    <p class="text-xs text-gray-400 dark:text-gray-500 mt-1">單檔不得超過 5MB</p>
                     <input type="file" id="imageInput" class="hidden" multiple accept="image/png,image/jpeg,image/webp">
                 </label>
             </section>
@@ -129,6 +130,7 @@
                     <li>支援一次選擇多張圖片，依加入順序合併為單一 PDF</li>
                     <li>「符合圖片尺寸」會讓每頁大小等於圖片本身</li>
                     <li>可拖曳預覽縮圖調整頁面順序，點擊 ✕ 可移除單張圖片</li>
+                    <li>單張圖片檔案不得超過 5MB，超過將自動略過</li>
                     <li>所有處理皆在瀏覽器本機完成，圖片不會上傳至伺服器</li>
                 </ul>
             </div>
@@ -182,9 +184,19 @@
         ['dragleave', 'drop'].forEach(evt => dropZone.addEventListener(evt, (e) => { e.preventDefault(); dropZone.classList.remove('border-blue-500'); }));
         dropZone.addEventListener('drop', (e) => addFiles(e.dataTransfer.files));
 
+        const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+
         async function addFiles(fileList) {
-            const files = Array.from(fileList).filter(f => f.type.startsWith('image/'));
-            if (files.length === 0) { showToast('請選擇圖片檔案'); return; }
+            const all = Array.from(fileList).filter(f => f.type.startsWith('image/'));
+            if (all.length === 0) { showToast('請選擇圖片檔案'); return; }
+
+            const oversized = all.filter(f => f.size > MAX_FILE_SIZE);
+            const files = all.filter(f => f.size <= MAX_FILE_SIZE);
+            if (oversized.length > 0) {
+                showToast(`已略過 ${oversized.length} 個檔案，單檔不得超過 5MB`, 3000);
+                if (files.length === 0) { imageInput.value = ''; return; }
+            }
+
             for (const file of files) {
                 await new Promise((resolve) => {
                     const reader = new FileReader();

--- a/png-to-pdf.html
+++ b/png-to-pdf.html
@@ -78,13 +78,12 @@
                     <svg class="w-12 h-12 mx-auto text-gray-400 dark:text-gray-500 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg>
                     <p class="text-lg font-medium mb-1">選擇圖片</p>
                     <p class="text-sm text-gray-500 dark:text-gray-400">或拖放圖片到此處（支援 PNG / JPEG / WebP，可多選）</p>
-                    <p class="text-xs text-gray-400 dark:text-gray-500 mt-1">單檔不得超過 5MB</p>
                     <input type="file" id="imageInput" class="hidden" multiple accept="image/png,image/jpeg,image/webp">
                 </label>
             </section>
 
             <!-- Options -->
-            <section class="bg-white dark:bg-gray-800 rounded-xl shadow p-4 sm:p-6 grid grid-cols-1 sm:grid-cols-3 gap-4">
+            <section class="bg-white dark:bg-gray-800 rounded-xl shadow p-4 sm:p-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
                 <div>
                     <label for="pageSize" class="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">頁面尺寸</label>
                     <select id="pageSize" class="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 touch-target">
@@ -104,6 +103,16 @@
                 <div>
                     <label for="margin" class="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">頁面邊距 (mm)</label>
                     <input type="number" id="margin" value="0" min="0" max="50" class="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 touch-target">
+                </div>
+                <div>
+                    <label for="targetSize" class="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">輸出檔案大小</label>
+                    <select id="targetSize" class="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 touch-target">
+                        <option value="0">不限制（原畫質）</option>
+                        <option value="1">小於 1 MB</option>
+                        <option value="2">小於 2 MB</option>
+                        <option value="5">小於 5 MB</option>
+                        <option value="10">小於 10 MB</option>
+                    </select>
                 </div>
             </section>
 
@@ -130,7 +139,7 @@
                     <li>支援一次選擇多張圖片，依加入順序合併為單一 PDF</li>
                     <li>「符合圖片尺寸」會讓每頁大小等於圖片本身</li>
                     <li>可拖曳預覽縮圖調整頁面順序，點擊 ✕ 可移除單張圖片</li>
-                    <li>單張圖片檔案不得超過 5MB，超過將自動略過</li>
+                    <li>「輸出檔案大小」會自動壓縮圖片以接近所選上限，選「不限制」則維持原畫質</li>
                     <li>所有處理皆在瀏覽器本機完成，圖片不會上傳至伺服器</li>
                 </ul>
             </div>
@@ -172,6 +181,32 @@
         let images = [];
         let nextId = 0;
         let dragId = null;
+        const imageElements = new Map(); // id -> HTMLImageElement (for re-encoding)
+
+        async function preloadImageElements() {
+            await Promise.all(images.map(item => new Promise((resolve) => {
+                if (imageElements.has(item.id)) { resolve(); return; }
+                const el = new Image();
+                el.onload = () => { imageElements.set(item.id, el); resolve(); };
+                el.onerror = () => resolve();
+                el.src = item.dataUrl;
+            })));
+        }
+
+        function encodeJpeg(item, quality, scale) {
+            const el = imageElements.get(item.id);
+            if (!el) return item.dataUrl;
+            const w = Math.max(1, Math.round(item.width * scale));
+            const h = Math.max(1, Math.round(item.height * scale));
+            const canvas = document.createElement('canvas');
+            canvas.width = w;
+            canvas.height = h;
+            const ctx = canvas.getContext('2d');
+            ctx.fillStyle = '#ffffff'; // flatten transparency for JPEG
+            ctx.fillRect(0, 0, w, h);
+            ctx.drawImage(el, 0, 0, w, h);
+            return canvas.toDataURL('image/jpeg', quality);
+        }
 
         const imageInput = document.getElementById('imageInput');
         const previewEl = document.getElementById('preview');
@@ -184,18 +219,9 @@
         ['dragleave', 'drop'].forEach(evt => dropZone.addEventListener(evt, (e) => { e.preventDefault(); dropZone.classList.remove('border-blue-500'); }));
         dropZone.addEventListener('drop', (e) => addFiles(e.dataTransfer.files));
 
-        const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
-
         async function addFiles(fileList) {
-            const all = Array.from(fileList).filter(f => f.type.startsWith('image/'));
-            if (all.length === 0) { showToast('請選擇圖片檔案'); return; }
-
-            const oversized = all.filter(f => f.size > MAX_FILE_SIZE);
-            const files = all.filter(f => f.size <= MAX_FILE_SIZE);
-            if (oversized.length > 0) {
-                showToast(`已略過 ${oversized.length} 個檔案，單檔不得超過 5MB`, 3000);
-                if (files.length === 0) { imageInput.value = ''; return; }
-            }
+            const files = Array.from(fileList).filter(f => f.type.startsWith('image/'));
+            if (files.length === 0) { showToast('請選擇圖片檔案'); return; }
 
             for (const file of files) {
                 await new Promise((resolve) => {
@@ -282,49 +308,85 @@
                 const pageSize = document.getElementById('pageSize').value;
                 const orientationOpt = document.getElementById('orientation').value;
                 const margin = Math.max(0, Number(document.getElementById('margin').value) || 0);
+                const targetMB = Number(document.getElementById('targetSize').value) || 0;
                 const PX_TO_MM = 0.2645833333; // 96 dpi
 
-                let pdf = null;
+                // Build a PDF. quality=null keeps original images; otherwise re-encode
+                // each image to JPEG at the given quality and resolution scale.
+                function buildPdf(quality, scale) {
+                    let pdf = null;
+                    for (const item of images) {
+                        const imgWmm = item.width * PX_TO_MM;
+                        const imgHmm = item.height * PX_TO_MM;
 
-                for (let i = 0; i < images.length; i++) {
-                    statusEl.textContent = `正在加入第 ${i + 1}/${images.length} 張圖片...`;
-                    const item = images[i];
-                    const imgWmm = item.width * PX_TO_MM;
-                    const imgHmm = item.height * PX_TO_MM;
+                        let pageW, pageH;
+                        if (pageSize === 'fit') {
+                            pageW = imgWmm + margin * 2;
+                            pageH = imgHmm + margin * 2;
+                        } else {
+                            const dims = pageSize === 'a4' ? [210, 297] : [215.9, 279.4];
+                            const landscape = orientationOpt === 'landscape' || (orientationOpt === 'auto' && imgWmm > imgHmm);
+                            pageW = landscape ? dims[1] : dims[0];
+                            pageH = landscape ? dims[0] : dims[1];
+                        }
 
-                    let pageW, pageH;
-                    if (pageSize === 'fit') {
-                        pageW = imgWmm + margin * 2;
-                        pageH = imgHmm + margin * 2;
-                    } else {
-                        const dims = pageSize === 'a4' ? [210, 297] : [215.9, 279.4];
-                        const landscape = orientationOpt === 'landscape' || (orientationOpt === 'auto' && imgWmm > imgHmm);
-                        pageW = landscape ? dims[1] : dims[0];
-                        pageH = landscape ? dims[0] : dims[1];
+                        const orientation = pageW > pageH ? 'landscape' : 'portrait';
+                        if (pdf === null) {
+                            pdf = new jsPDF({ orientation, unit: 'mm', format: [pageW, pageH] });
+                        } else {
+                            pdf.addPage([pageW, pageH], orientation);
+                        }
+
+                        const availW = pageW - margin * 2;
+                        const availH = pageH - margin * 2;
+                        const ratio = Math.min(availW / imgWmm, availH / imgHmm);
+                        const drawW = imgWmm * ratio;
+                        const drawH = imgHmm * ratio;
+                        const x = margin + (availW - drawW) / 2;
+                        const y = margin + (availH - drawH) / 2;
+
+                        let dataUrl, format;
+                        if (quality === null) {
+                            dataUrl = item.dataUrl;
+                            format = item.dataUrl.startsWith('data:image/jpeg') ? 'JPEG' : 'PNG';
+                        } else {
+                            dataUrl = encodeJpeg(item, quality, scale);
+                            format = 'JPEG';
+                        }
+                        pdf.addImage(dataUrl, format, x, y, drawW, drawH);
                     }
+                    return pdf;
+                }
 
-                    const orientation = pageW > pageH ? 'landscape' : 'portrait';
-                    if (pdf === null) {
-                        pdf = new jsPDF({ orientation, unit: 'mm', format: [pageW, pageH] });
-                    } else {
-                        pdf.addPage([pageW, pageH], orientation);
+                let pdf;
+                if (targetMB === 0) {
+                    statusEl.textContent = '正在產生 PDF...';
+                    pdf = buildPdf(null, 1);
+                } else {
+                    await preloadImageElements();
+                    const targetBytes = targetMB * 1024 * 1024;
+                    const qualities = [0.92, 0.85, 0.75, 0.65, 0.55, 0.45, 0.35];
+                    let scale = 1, best = null, bestSize = Infinity, done = false;
+                    while (scale >= 0.3 && !done) {
+                        for (const q of qualities) {
+                            statusEl.textContent = `壓縮中（解析度 ${Math.round(scale * 100)}%、品質 ${Math.round(q * 100)}%）...`;
+                            await new Promise(r => setTimeout(r));
+                            const candidate = buildPdf(q, scale);
+                            const size = candidate.output('blob').size;
+                            if (size < bestSize) { best = candidate; bestSize = size; }
+                            if (size <= targetBytes) { pdf = candidate; done = true; break; }
+                        }
+                        scale *= 0.8;
                     }
-
-                    // Fit image into the page content area, preserving aspect ratio
-                    const availW = pageW - margin * 2;
-                    const availH = pageH - margin * 2;
-                    const ratio = Math.min(availW / imgWmm, availH / imgHmm);
-                    const drawW = imgWmm * ratio;
-                    const drawH = imgHmm * ratio;
-                    const x = margin + (availW - drawW) / 2;
-                    const y = margin + (availH - drawH) / 2;
-
-                    const format = item.dataUrl.startsWith('data:image/jpeg') ? 'JPEG' : 'PNG';
-                    pdf.addImage(item.dataUrl, format, x, y, drawW, drawH);
+                    if (!pdf) {
+                        pdf = best;
+                        showToast(`已盡量壓縮至約 ${(bestSize / 1024 / 1024).toFixed(1)}MB，仍大於目標`, 3000);
+                    }
                 }
 
                 pdf.save(`images-${Date.now()}.pdf`);
-                statusEl.textContent = `完成！已合併 ${images.length} 張圖片`;
+                const finalSize = pdf.output('blob').size;
+                statusEl.textContent = `完成！已合併 ${images.length} 張圖片（約 ${(finalSize / 1024 / 1024).toFixed(2)} MB）`;
                 showToast('PDF 產生完成');
             } catch (error) {
                 console.error('產生 PDF 失敗:', error);


### PR DESCRIPTION
## Summary
PR #5 已合併初版 PNG 轉 PDF 工具，本 PR 補上後續的「輸出檔案大小」功能。

## Changes
- 新增「輸出檔案大小」選項：不限制（原畫質）/ 小於 1、2、5、10 MB
- 選擇大小上限時，自動以遞減的 JPEG 品質（92%→35%）重新編碼圖片以接近目標；若仍超標再逐步降低解析度（每輪 ×0.8）
- 完成後狀態列顯示實際輸出大小；壓到極限仍超標時以 toast 告知
- 透明區於 JPEG 編碼時以白底填平

## Notes
- 所有壓縮與 PDF 產生皆在瀏覽器本機完成，圖片不會上傳
- 尚未經瀏覽器實測，建議合併前以大圖選「小於 1MB」驗證效果

https://claude.ai/code/session_0166bqgtBfmULxk7gFWjWyoU

---
_Generated by [Claude Code](https://claude.ai/code/session_0166bqgtBfmULxk7gFWjWyoU)_