### PR TITLE
Add speech timer tool for estimating presentation duration

### DIFF
--- a/.github/scripts/update_toc.py
+++ b/.github/scripts/update_toc.py
@@ -18,6 +18,7 @@ TOOL_CATEGORIES = {
     'highlight_replace.html': 'text',
     'email.html': 'text',
     'word-replace.html': 'text',
+    'speech-timer.html': 'text',
 
     # 圖片工具
     'pdf-to-png.html': 'image',
@@ -57,6 +58,7 @@ TOOL_ICONS = {
     'highlight_replace.html': '🖍️',
     'email.html': '📧',
     'word-replace.html': '📃',
+    'speech-timer.html': '⏱️',
     'pdf-to-png.html': '📄',
     'pdf-to-txt.html': '📄',
     'png-to-pdf.html': '🖼️',
@@ -90,6 +92,7 @@ TOOL_KEYWORDS = {
     'highlight_replace.html': '取代 替換 replace 識別 highlight',
     'email.html': '信箱 email 郵件 暱稱 提取 extract',
     'word-replace.html': 'word docx 批次 取代 替換 文件 office replace batch',
+    'speech-timer.html': '演講 時間 計算 簡報 語速 speech timer presentation wpm 推銷 腳本',
     'pdf-to-png.html': 'pdf png 轉換 圖片 convert',
     'pdf-to-txt.html': 'pdf txt 純文字 擷取 抽取 文字 extract text',
     'png-to-pdf.html': 'png pdf 圖片 合併 轉換 jpg jpeg convert merge',

--- a/components/shared.js
+++ b/components/shared.js
@@ -22,6 +22,7 @@ const TOOLS = {
         { id: 'highlight-replace', name: '文字取代', icon: '🖍️', href: 'highlight_replace.html', desc: '批量識別和取代文字' },
         { id: 'email', name: '信箱提取', icon: '📧', href: 'email.html', desc: '從文字中提取信箱與暱稱' },
         { id: 'word-replace', name: 'Word 批次取代', icon: '📃', href: 'word-replace.html', desc: 'Word/docx 文件批次取代' },
+        { id: 'speech-timer', name: '演講時間計算機', icon: '⏱️', href: 'speech-timer.html', desc: '估算演講、簡報所需時長' },
     ],
     image: [
         { id: 'pdf-to-png', name: 'PDF 轉 PNG', icon: '📄', href: 'pdf-to-png.html', desc: '將 PDF 轉換為圖片' },

--- a/speech-timer.html
+++ b/speech-timer.html
@@ -1,0 +1,591 @@
+<!DOCTYPE html>
+<html lang="zh-TW" class="scroll-smooth">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <!-- SEO 基礎 -->
+    <title>演講時間計算機 - 估算演講與簡報時長 | FeiFei Tools</title>
+    <meta name="description" content="免費線上演講時間計算機，透過字數或貼上文字估算演講、簡報、推銷所需時長，提供慢速、正常與快速語速比較。">
+    <meta name="keywords" content="演講時間,演講計算,簡報時間,語速計算,speech timer,presentation timer,字數時間">
+    <meta name="author" content="FeiFei">
+    <link rel="canonical" href="https://tool.feifei.tw/speech-timer.html">
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://tool.feifei.tw/speech-timer.html">
+    <meta property="og:title" content="演講時間計算機 | FeiFei Tools">
+    <meta property="og:description" content="透過字數或貼上文字估算演講、簡報所需時長，提供慢速、正常與快速語速比較。">
+    <meta property="og:image" content="https://tool.feifei.tw/og-image.png">
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="演講時間計算機 | FeiFei Tools">
+    <meta name="twitter:description" content="透過字數或貼上文字估算演講、簡報所需時長，提供慢速、正常與快速語速比較。">
+
+    <!-- Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-B20B804DQS"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-B20B804DQS');
+    </script>
+
+    <!-- 防止主題閃爍 -->
+    <script>
+        (function() {
+            const saved = localStorage.getItem('theme');
+            const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+            if (saved === 'dark' || (!saved && prefersDark)) {
+                document.documentElement.classList.add('dark');
+            }
+        })();
+    </script>
+
+    <!-- Tailwind CSS -->
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+        tailwind.config = {
+            darkMode: 'class',
+            theme: {
+                extend: {
+                    fontFamily: {
+                        sans: ['Noto Sans TC', 'system-ui', 'sans-serif'],
+                    }
+                }
+            }
+        }
+    </script>
+
+    <!-- Google Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;700&display=swap" rel="stylesheet">
+
+    <!-- JSON-LD -->
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "WebApplication",
+        "name": "演講時間計算機",
+        "url": "https://tool.feifei.tw/speech-timer.html",
+        "description": "透過字數或貼上文字估算演講所需時長",
+        "applicationCategory": "UtilityApplication",
+        "operatingSystem": "Any",
+        "offers": { "@type": "Offer", "price": "0", "priceCurrency": "TWD" }
+    }
+    </script>
+
+    <style>
+        .touch-target { min-height: 44px; min-width: 44px; }
+        .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }
+        .speed-btn { transition: all 0.2s; }
+        .speed-btn.active { ring: 2px; }
+    </style>
+</head>
+<body class="font-sans bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 antialiased">
+
+    <!-- Skip Link -->
+    <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 bg-blue-600 text-white px-4 py-2 rounded-lg z-[100]">
+        跳至主要內容
+    </a>
+
+    <!-- Desktop Header -->
+    <header class="hidden md:block sticky top-0 z-40 bg-white/80 dark:bg-gray-800/80 backdrop-blur-lg border-b border-gray-200 dark:border-gray-700">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex items-center justify-between h-16">
+                <a href="index.html" class="flex items-center gap-2 touch-target" aria-label="返回首頁">
+                    <span class="text-2xl" aria-hidden="true">🛠️</span>
+                    <span class="font-bold text-xl">FeiFei Tools</span>
+                </a>
+                <nav class="flex items-center gap-1" aria-label="麵包屑">
+                    <a href="index.html" class="px-3 py-2 rounded-lg text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 text-sm">首頁</a>
+                    <span class="text-gray-300 dark:text-gray-600">/</span>
+                    <span class="px-3 py-2 text-gray-900 dark:text-white font-medium text-sm">演講時間計算機</span>
+                </nav>
+                <button id="theme-toggle-desktop" class="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors touch-target" aria-label="切換深色模式">
+                    <svg class="w-6 h-6 hidden dark:block text-yellow-400" fill="currentColor" viewBox="0 0 20 20"><path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+                    <svg class="w-6 h-6 block dark:hidden text-gray-600" fill="currentColor" viewBox="0 0 20 20"><path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/></svg>
+                </button>
+            </div>
+        </div>
+    </header>
+
+    <!-- Main Content -->
+    <main id="main-content" class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-6 md:py-8 pb-24 md:pb-8">
+
+        <!-- Page Header -->
+        <div class="mb-6">
+            <h1 class="text-2xl md:text-3xl font-bold mb-2 flex items-center gap-3">
+                <span class="text-3xl" aria-hidden="true">⏱️</span>
+                演講時間計算機
+            </h1>
+            <p class="text-gray-600 dark:text-gray-400">
+                透過字數或貼上文字來估算演講、簡報、推銷所需時長
+            </p>
+        </div>
+
+        <div class="space-y-6">
+
+            <!-- Example Templates -->
+            <section>
+                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">嘗試範例</label>
+                <div class="flex flex-wrap gap-2">
+                    <button onclick="loadExample('keynote')" class="px-4 py-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg text-sm hover:border-blue-500 dark:hover:border-blue-400 transition-colors touch-target">
+                        🎤 主題演講開場
+                    </button>
+                    <button onclick="loadExample('classroom')" class="px-4 py-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg text-sm hover:border-blue-500 dark:hover:border-blue-400 transition-colors touch-target">
+                        📚 課堂演示
+                    </button>
+                    <button onclick="loadExample('pitch')" class="px-4 py-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg text-sm hover:border-blue-500 dark:hover:border-blue-400 transition-colors touch-target">
+                        🚀 創業募資推介
+                    </button>
+                </div>
+            </section>
+
+            <!-- Input Section -->
+            <section>
+                <div class="flex items-center justify-between mb-2">
+                    <label for="text-input" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                        草稿或字數
+                    </label>
+                    <div class="flex items-center gap-2">
+                        <button id="tab-text" onclick="switchTab('text')" class="px-3 py-1 text-xs rounded-full bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300 font-medium transition-colors">
+                            文本字數
+                        </button>
+                        <button id="tab-manual" onclick="switchTab('manual')" class="px-3 py-1 text-xs rounded-full bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 font-medium transition-colors">
+                            手動輸入字數
+                        </button>
+                    </div>
+                </div>
+
+                <!-- Text Input -->
+                <div id="input-text">
+                    <textarea id="text-input"
+                        class="w-full p-4 border border-gray-300 dark:border-gray-600 rounded-xl bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-y min-h-[160px] touch-target"
+                        placeholder="在此貼上您的演講稿、簡報筆記、影片腳本或重點摘要..."
+                        rows="6"
+                        oninput="calculate()"></textarea>
+                </div>
+
+                <!-- Manual Word Count Input -->
+                <div id="input-manual" class="hidden">
+                    <div class="flex items-center gap-3">
+                        <input type="number" id="manual-count" min="0" max="100000" value=""
+                            class="w-full p-4 border border-gray-300 dark:border-gray-600 rounded-xl bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent touch-target"
+                            placeholder="輸入總字數（例如：1500）"
+                            oninput="calculate()">
+                    </div>
+                </div>
+            </section>
+
+            <!-- Settings -->
+            <section class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-4 space-y-5">
+
+                <!-- Pause Buffer -->
+                <div>
+                    <div class="flex items-center justify-between mb-2">
+                        <label for="buffer-range" class="text-sm font-medium text-gray-700 dark:text-gray-300">暫停緩衝</label>
+                        <span id="buffer-value" class="text-sm font-semibold text-blue-600 dark:text-blue-400">10% 緩衝</span>
+                    </div>
+                    <input type="range" id="buffer-range" min="0" max="30" value="10" step="1"
+                        class="w-full h-2 bg-gray-200 dark:bg-gray-700 rounded-lg appearance-none cursor-pointer accent-blue-600"
+                        oninput="updateBuffer(); calculate()">
+                    <div class="flex justify-between text-xs text-gray-400 mt-1">
+                        <span>0%</span>
+                        <span>15%</span>
+                        <span>30%</span>
+                    </div>
+                </div>
+
+                <!-- Speaking Speed -->
+                <div>
+                    <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">說話語速</label>
+                    <div class="grid grid-cols-3 gap-3">
+                        <button onclick="setSpeed(110)" id="speed-110"
+                            class="speed-btn p-3 rounded-xl border-2 border-gray-200 dark:border-gray-600 text-center hover:border-blue-400 transition-all touch-target">
+                            <div class="text-lg font-bold text-gray-900 dark:text-white">慢速</div>
+                            <div class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">110 wpm · 沉穩</div>
+                        </button>
+                        <button onclick="setSpeed(140)" id="speed-140"
+                            class="speed-btn p-3 rounded-xl border-2 border-gray-200 dark:border-gray-600 text-center hover:border-blue-400 transition-all touch-target">
+                            <div class="text-lg font-bold text-gray-900 dark:text-white">正常</div>
+                            <div class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">140 wpm · 清晰</div>
+                        </button>
+                        <button onclick="setSpeed(170)" id="speed-170"
+                            class="speed-btn p-3 rounded-xl border-2 border-blue-500 dark:border-blue-400 bg-blue-50 dark:bg-blue-900/20 text-center touch-target">
+                            <div class="text-lg font-bold text-blue-600 dark:text-blue-400">快速</div>
+                            <div class="text-xs text-blue-500 dark:text-blue-300 mt-0.5">170 wpm · 活力</div>
+                        </button>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Action Buttons -->
+            <div class="flex flex-wrap gap-3">
+                <button onclick="calculate()" class="inline-flex items-center justify-center gap-2 px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-xl transition-colors touch-target">
+                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+                    ⏱ 計算演講時間
+                </button>
+                <button onclick="clearAll()" class="inline-flex items-center justify-center gap-2 px-6 py-3 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 font-medium rounded-xl transition-colors touch-target">
+                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
+                    ✕ 清除
+                </button>
+            </div>
+
+            <!-- Live Preview Bar -->
+            <section class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-4">
+                <div class="flex items-center justify-between mb-3">
+                    <span class="text-2xl font-bold text-gray-900 dark:text-white" id="live-time">0:00</span>
+                    <span class="text-sm text-gray-500 dark:text-gray-400">以 <span id="live-wpm">170</span> wpm 即時預估</span>
+                </div>
+                <div class="grid grid-cols-3 gap-3 text-center">
+                    <div class="p-2 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
+                        <p class="text-lg font-bold text-gray-900 dark:text-white" id="live-words">0</p>
+                        <p class="text-xs text-gray-500 dark:text-gray-400">字數</p>
+                    </div>
+                    <div class="p-2 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
+                        <p class="text-lg font-bold text-gray-900 dark:text-white" id="live-buffer">10%</p>
+                        <p class="text-xs text-gray-500 dark:text-gray-400">緩衝</p>
+                    </div>
+                    <div class="p-2 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
+                        <p class="text-lg font-bold text-gray-900 dark:text-white" id="live-speed">170</p>
+                        <p class="text-xs text-gray-500 dark:text-gray-400">WPM</p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Results Section -->
+            <section class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden">
+                <div class="px-4 py-3 bg-gray-50 dark:bg-gray-700/50 border-b border-gray-200 dark:border-gray-600">
+                    <h2 class="font-semibold text-gray-900 dark:text-white">時間估算結果</h2>
+                </div>
+
+                <!-- Base Time -->
+                <div class="p-4 border-b border-gray-200 dark:border-gray-600">
+                    <div class="flex items-center justify-between">
+                        <span class="text-gray-600 dark:text-gray-400">基礎時間</span>
+                        <span class="text-xl font-bold text-gray-900 dark:text-white" id="result-base">0:00</span>
+                    </div>
+                </div>
+
+                <!-- Speed Comparison -->
+                <div class="p-4 grid grid-cols-3 gap-4">
+                    <div class="text-center p-4 bg-indigo-50 dark:bg-indigo-900/20 rounded-lg">
+                        <p class="text-xs text-gray-500 dark:text-gray-400 mb-1">慢速</p>
+                        <p class="text-2xl font-bold text-indigo-600 dark:text-indigo-400" id="result-slow">0:00</p>
+                        <p class="text-xs text-gray-400 mt-1">110 wpm</p>
+                    </div>
+                    <div class="text-center p-4 bg-green-50 dark:bg-green-900/20 rounded-lg">
+                        <p class="text-xs text-gray-500 dark:text-gray-400 mb-1">正常</p>
+                        <p class="text-2xl font-bold text-green-600 dark:text-green-400" id="result-normal">0:00</p>
+                        <p class="text-xs text-gray-400 mt-1">140 wpm</p>
+                    </div>
+                    <div class="text-center p-4 bg-amber-50 dark:bg-amber-900/20 rounded-lg">
+                        <p class="text-xs text-gray-500 dark:text-gray-400 mb-1">快速</p>
+                        <p class="text-2xl font-bold text-amber-600 dark:text-amber-400" id="result-fast">0:00</p>
+                        <p class="text-xs text-gray-400 mt-1">170 wpm</p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Per-Section Timing -->
+            <section id="section-timing" class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden hidden">
+                <div class="px-4 py-3 bg-gray-50 dark:bg-gray-700/50 border-b border-gray-200 dark:border-gray-600">
+                    <h2 class="font-semibold text-gray-900 dark:text-white">逐段計時</h2>
+                </div>
+                <div id="section-list" class="divide-y divide-gray-100 dark:divide-gray-700">
+                </div>
+            </section>
+
+            <!-- Copy Result -->
+            <div class="flex justify-end">
+                <button onclick="copyResult()" class="inline-flex items-center justify-center gap-2 px-6 py-3 bg-green-600 hover:bg-green-700 text-white font-medium rounded-xl transition-colors touch-target">
+                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3"/></svg>
+                    複製結果
+                </button>
+            </div>
+
+        </div>
+    </main>
+
+    <!-- Mobile Bottom Navigation -->
+    <nav class="md:hidden fixed bottom-0 left-0 right-0 z-50 bg-white/90 dark:bg-gray-800/90 backdrop-blur-lg border-t border-gray-200 dark:border-gray-700" style="padding-bottom: env(safe-area-inset-bottom, 0);" aria-label="行動版導覽">
+        <div class="grid grid-cols-5 h-16">
+            <a href="index.html" class="flex flex-col items-center justify-center text-gray-600 dark:text-gray-400 touch-target">
+                <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 20 20"><path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z"/></svg>
+                <span class="text-xs mt-0.5">首頁</span>
+            </a>
+            <a href="text-stats.html" class="flex flex-col items-center justify-center text-gray-600 dark:text-gray-400 touch-target">
+                <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4z" clip-rule="evenodd"/></svg>
+                <span class="text-xs mt-0.5">文字</span>
+            </a>
+            <a href="pdf-to-png.html" class="flex flex-col items-center justify-center text-gray-600 dark:text-gray-400 touch-target">
+                <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg>
+                <span class="text-xs mt-0.5">圖片</span>
+            </a>
+            <a href="encry.html" class="flex flex-col items-center justify-center text-gray-600 dark:text-gray-400 touch-target">
+                <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/></svg>
+                <span class="text-xs mt-0.5">開發</span>
+            </a>
+            <button id="theme-toggle-mobile" class="flex flex-col items-center justify-center text-gray-600 dark:text-gray-400 touch-target" aria-label="切換主題">
+                <svg class="w-6 h-6 hidden dark:block" fill="currentColor" viewBox="0 0 20 20"><path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+                <svg class="w-6 h-6 block dark:hidden" fill="currentColor" viewBox="0 0 20 20"><path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/></svg>
+                <span class="text-xs mt-0.5">主題</span>
+            </button>
+        </div>
+    </nav>
+
+    <!-- Toast -->
+    <div id="toast" class="fixed bottom-24 md:bottom-8 left-1/2 -translate-x-1/2 bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 px-4 py-2 rounded-lg shadow-lg transform transition-all duration-300 opacity-0 translate-y-4 pointer-events-none z-[60]" role="alert">
+        <span id="toast-message"></span>
+    </div>
+
+    <script>
+        // Theme Toggle
+        function toggleTheme() {
+            const isDark = document.documentElement.classList.toggle('dark');
+            localStorage.setItem('theme', isDark ? 'dark' : 'light');
+        }
+        document.getElementById('theme-toggle-desktop')?.addEventListener('click', toggleTheme);
+        document.getElementById('theme-toggle-mobile')?.addEventListener('click', toggleTheme);
+
+        // Toast
+        function showToast(message, duration = 2000) {
+            const toast = document.getElementById('toast');
+            document.getElementById('toast-message').textContent = message;
+            toast.classList.remove('opacity-0', 'translate-y-4', 'pointer-events-none');
+            toast.classList.add('opacity-100', 'translate-y-0');
+            setTimeout(() => {
+                toast.classList.add('opacity-0', 'translate-y-4', 'pointer-events-none');
+                toast.classList.remove('opacity-100', 'translate-y-0');
+            }, duration);
+        }
+
+        // State
+        let currentSpeed = 170;
+        let currentTab = 'text';
+
+        // Examples
+        const EXAMPLES = {
+            keynote: `各位來賓、各位夥伴，大家早安。
+
+今天非常榮幸站在這裡，跟大家分享我們對未來科技趨勢的看法。在過去的一年裡，人工智慧技術取得了前所未有的突破，不僅改變了我們工作的方式，更重新定義了人機互動的邊界。
+
+我想用接下來的十五分鐘，帶大家一起探索三個關鍵趨勢：第一，生成式 AI 如何重塑創意產業；第二，邊緣運算與 AI 的結合將帶來什麼新機會；第三，我們該如何負責任地發展這些技術。
+
+讓我們從第一個趨勢開始。想像一下，一位設計師只需要描述她心中的畫面，AI 就能在幾秒鐘內產生數十個設計方案。這不是科幻小說，這是正在發生的事實。`,
+
+            classroom: `同學們好，今天我們要來學習資料結構中的二元搜尋樹。
+
+首先，讓我們回顧一下上週學過的鏈結串列。鏈結串列的搜尋時間複雜度是 O(n)，因為我們必須從頭走到尾。那有沒有更快的方法呢？
+
+答案就是今天的主題——二元搜尋樹。它的核心概念很簡單：每個節點的左子樹都比它小，右子樹都比它大。這樣我們每次比較都能排除一半的資料，平均搜尋時間可以降到 O(log n)。
+
+現在請大家打開課本第 87 頁，我們來看第一個範例。`,
+
+            pitch: `投資人您好，我是 TechFlow 的創辦人兼執行長。
+
+我們正在解決一個價值 500 億美元的問題：企業內部知識管理的低效率。根據 McKinsey 的調查，員工每天花 1.8 小時在搜尋內部資訊上，這相當於每年浪費 9.3 週的生產力。
+
+TechFlow 用 AI 驅動的知識圖譜技術，讓企業資訊的存取速度提升 10 倍。我們的解決方案已經獲得 3 家財星 500 大企業的採用，月營收成長率達 40%。
+
+我們正在進行 A 輪融資，目標金額 1500 萬美元，將用於擴展銷售團隊和深化 AI 技術研發。
+
+謝謝各位的時間，期待與您進一步交流。`
+        };
+
+        function loadExample(key) {
+            if (currentTab !== 'text') switchTab('text');
+            document.getElementById('text-input').value = EXAMPLES[key];
+            calculate();
+            showToast('已載入範例');
+        }
+
+        // Tab switching
+        function switchTab(tab) {
+            currentTab = tab;
+            const textTab = document.getElementById('tab-text');
+            const manualTab = document.getElementById('tab-manual');
+            const textInput = document.getElementById('input-text');
+            const manualInput = document.getElementById('input-manual');
+
+            if (tab === 'text') {
+                textTab.className = 'px-3 py-1 text-xs rounded-full bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300 font-medium transition-colors';
+                manualTab.className = 'px-3 py-1 text-xs rounded-full bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 font-medium transition-colors';
+                textInput.classList.remove('hidden');
+                manualInput.classList.add('hidden');
+            } else {
+                manualTab.className = 'px-3 py-1 text-xs rounded-full bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300 font-medium transition-colors';
+                textTab.className = 'px-3 py-1 text-xs rounded-full bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 font-medium transition-colors';
+                manualInput.classList.remove('hidden');
+                textInput.classList.add('hidden');
+            }
+            calculate();
+        }
+
+        // Speed selection
+        function setSpeed(wpm) {
+            currentSpeed = wpm;
+            [110, 140, 170].forEach(s => {
+                const btn = document.getElementById(`speed-${s}`);
+                if (s === wpm) {
+                    btn.className = 'speed-btn p-3 rounded-xl border-2 border-blue-500 dark:border-blue-400 bg-blue-50 dark:bg-blue-900/20 text-center touch-target';
+                    btn.querySelector('div:first-child').className = 'text-lg font-bold text-blue-600 dark:text-blue-400';
+                    btn.querySelector('div:last-child').className = 'text-xs text-blue-500 dark:text-blue-300 mt-0.5';
+                } else {
+                    btn.className = 'speed-btn p-3 rounded-xl border-2 border-gray-200 dark:border-gray-600 text-center hover:border-blue-400 transition-all touch-target';
+                    btn.querySelector('div:first-child').className = 'text-lg font-bold text-gray-900 dark:text-white';
+                    btn.querySelector('div:last-child').className = 'text-xs text-gray-500 dark:text-gray-400 mt-0.5';
+                }
+            });
+            calculate();
+        }
+
+        // Buffer display
+        function updateBuffer() {
+            const val = document.getElementById('buffer-range').value;
+            document.getElementById('buffer-value').textContent = `${val}% 緩衝`;
+        }
+
+        // Count words in text (supports Chinese + English)
+        function countWords(text) {
+            if (!text.trim()) return 0;
+            const chinese = (text.match(/[一-鿿㐀-䶿]/g) || []).length;
+            const english = (text.match(/\b[a-zA-Z]+\b/g) || []).length;
+            return chinese + english;
+        }
+
+        // Get sections (split by double newline or paragraph)
+        function getSections(text) {
+            if (!text.trim()) return [];
+            return text.split(/\n\s*\n/).filter(s => s.trim()).map(s => s.trim());
+        }
+
+        // Format time (seconds -> M:SS or H:MM:SS)
+        function formatTime(seconds) {
+            seconds = Math.round(seconds);
+            if (seconds < 0) seconds = 0;
+            const h = Math.floor(seconds / 3600);
+            const m = Math.floor((seconds % 3600) / 60);
+            const s = seconds % 60;
+            if (h > 0) {
+                return `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+            }
+            return `${m}:${String(s).padStart(2, '0')}`;
+        }
+
+        // Calculate time from word count and wpm
+        function calcSeconds(words, wpm, bufferPct) {
+            if (words <= 0 || wpm <= 0) return 0;
+            const base = (words / wpm) * 60;
+            return base * (1 + bufferPct / 100);
+        }
+
+        // Main calculation
+        function calculate() {
+            const buffer = parseInt(document.getElementById('buffer-range').value) || 0;
+            let totalWords = 0;
+            let sections = [];
+
+            if (currentTab === 'text') {
+                const text = document.getElementById('text-input').value;
+                totalWords = countWords(text);
+                sections = getSections(text);
+            } else {
+                totalWords = parseInt(document.getElementById('manual-count').value) || 0;
+            }
+
+            // Live preview
+            const liveSeconds = calcSeconds(totalWords, currentSpeed, buffer);
+            document.getElementById('live-time').textContent = formatTime(liveSeconds);
+            document.getElementById('live-wpm').textContent = currentSpeed;
+            document.getElementById('live-words').textContent = totalWords.toLocaleString();
+            document.getElementById('live-buffer').textContent = `${buffer}%`;
+            document.getElementById('live-speed').textContent = currentSpeed;
+
+            // Results
+            const baseSec = (totalWords / (currentSpeed || 170)) * 60;
+            document.getElementById('result-base').textContent = formatTime(baseSec);
+            document.getElementById('result-slow').textContent = formatTime(calcSeconds(totalWords, 110, buffer));
+            document.getElementById('result-normal').textContent = formatTime(calcSeconds(totalWords, 140, buffer));
+            document.getElementById('result-fast').textContent = formatTime(calcSeconds(totalWords, 170, buffer));
+
+            // Per-section timing
+            const sectionEl = document.getElementById('section-timing');
+            const sectionList = document.getElementById('section-list');
+
+            if (sections.length > 1) {
+                sectionEl.classList.remove('hidden');
+                sectionList.innerHTML = '';
+                let cumulative = 0;
+
+                sections.forEach((sec, i) => {
+                    const words = countWords(sec);
+                    const secs = calcSeconds(words, currentSpeed, buffer);
+                    cumulative += secs;
+                    const preview = sec.length > 60 ? sec.substring(0, 60) + '...' : sec;
+
+                    const row = document.createElement('div');
+                    row.className = 'px-4 py-3 flex items-center gap-3';
+                    row.innerHTML = `
+                        <span class="flex-shrink-0 w-7 h-7 rounded-full bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 text-xs font-bold flex items-center justify-center">${i + 1}</span>
+                        <div class="flex-1 min-w-0">
+                            <p class="text-sm text-gray-700 dark:text-gray-300 truncate">${escapeHtml(preview)}</p>
+                            <p class="text-xs text-gray-400 mt-0.5">${words} 字</p>
+                        </div>
+                        <div class="text-right flex-shrink-0">
+                            <p class="text-sm font-semibold text-gray-900 dark:text-white">${formatTime(secs)}</p>
+                            <p class="text-xs text-gray-400">累計 ${formatTime(cumulative)}</p>
+                        </div>
+                    `;
+                    sectionList.appendChild(row);
+                });
+            } else {
+                sectionEl.classList.add('hidden');
+            }
+        }
+
+        function escapeHtml(text) {
+            const div = document.createElement('div');
+            div.textContent = text;
+            return div.innerHTML;
+        }
+
+        function clearAll() {
+            document.getElementById('text-input').value = '';
+            document.getElementById('manual-count').value = '';
+            document.getElementById('buffer-range').value = 10;
+            updateBuffer();
+            calculate();
+            showToast('已清除');
+        }
+
+        async function copyResult() {
+            const words = document.getElementById('live-words').textContent;
+            const buffer = document.getElementById('live-buffer').textContent;
+            const result = `演講時間估算結果
+================
+總字數：${words}
+暫停緩衝：${buffer}
+基礎時間：${document.getElementById('result-base').textContent}
+慢速 (110 wpm)：${document.getElementById('result-slow').textContent}
+正常 (140 wpm)：${document.getElementById('result-normal').textContent}
+快速 (170 wpm)：${document.getElementById('result-fast').textContent}`;
+
+            try {
+                await navigator.clipboard.writeText(result);
+                showToast('已複製到剪貼簿');
+            } catch (err) {
+                showToast('複製失敗');
+            }
+        }
+
+        // Initialize
+        updateBuffer();
+        calculate();
+    </script>
+
+</body>
+</html>

--- a/speech-timer.html
+++ b/speech-timer.html
@@ -77,6 +77,9 @@
     }
     </script>
 
+    <!-- Shared Components -->
+    <script src="components/shared.js"></script>
+
     <style>
         .touch-target { min-height: 44px; min-width: 44px; }
         .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }
@@ -85,32 +88,6 @@
     </style>
 </head>
 <body class="font-sans bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 antialiased">
-
-    <!-- Skip Link -->
-    <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 bg-blue-600 text-white px-4 py-2 rounded-lg z-[100]">
-        跳至主要內容
-    </a>
-
-    <!-- Desktop Header -->
-    <header class="hidden md:block sticky top-0 z-40 bg-white/80 dark:bg-gray-800/80 backdrop-blur-lg border-b border-gray-200 dark:border-gray-700">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex items-center justify-between h-16">
-                <a href="index.html" class="flex items-center gap-2 touch-target" aria-label="返回首頁">
-                    <span class="text-2xl" aria-hidden="true">🛠️</span>
-                    <span class="font-bold text-xl">FeiFei Tools</span>
-                </a>
-                <nav class="flex items-center gap-1" aria-label="麵包屑">
-                    <a href="index.html" class="px-3 py-2 rounded-lg text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 text-sm">首頁</a>
-                    <span class="text-gray-300 dark:text-gray-600">/</span>
-                    <span class="px-3 py-2 text-gray-900 dark:text-white font-medium text-sm">演講時間計算機</span>
-                </nav>
-                <button id="theme-toggle-desktop" class="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors touch-target" aria-label="切換深色模式">
-                    <svg class="w-6 h-6 hidden dark:block text-yellow-400" fill="currentColor" viewBox="0 0 20 20"><path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
-                    <svg class="w-6 h-6 block dark:hidden text-gray-600" fill="currentColor" viewBox="0 0 20 20"><path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/></svg>
-                </button>
-            </div>
-        </div>
-    </header>
 
     <!-- Main Content -->
     <main id="main-content" class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-6 md:py-8 pb-24 md:pb-8">
@@ -310,58 +287,10 @@
         </div>
     </main>
 
-    <!-- Mobile Bottom Navigation -->
-    <nav class="md:hidden fixed bottom-0 left-0 right-0 z-50 bg-white/90 dark:bg-gray-800/90 backdrop-blur-lg border-t border-gray-200 dark:border-gray-700" style="padding-bottom: env(safe-area-inset-bottom, 0);" aria-label="行動版導覽">
-        <div class="grid grid-cols-5 h-16">
-            <a href="index.html" class="flex flex-col items-center justify-center text-gray-600 dark:text-gray-400 touch-target">
-                <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 20 20"><path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z"/></svg>
-                <span class="text-xs mt-0.5">首頁</span>
-            </a>
-            <a href="text-stats.html" class="flex flex-col items-center justify-center text-gray-600 dark:text-gray-400 touch-target">
-                <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4z" clip-rule="evenodd"/></svg>
-                <span class="text-xs mt-0.5">文字</span>
-            </a>
-            <a href="pdf-to-png.html" class="flex flex-col items-center justify-center text-gray-600 dark:text-gray-400 touch-target">
-                <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg>
-                <span class="text-xs mt-0.5">圖片</span>
-            </a>
-            <a href="encry.html" class="flex flex-col items-center justify-center text-gray-600 dark:text-gray-400 touch-target">
-                <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/></svg>
-                <span class="text-xs mt-0.5">開發</span>
-            </a>
-            <button id="theme-toggle-mobile" class="flex flex-col items-center justify-center text-gray-600 dark:text-gray-400 touch-target" aria-label="切換主題">
-                <svg class="w-6 h-6 hidden dark:block" fill="currentColor" viewBox="0 0 20 20"><path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
-                <svg class="w-6 h-6 block dark:hidden" fill="currentColor" viewBox="0 0 20 20"><path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/></svg>
-                <span class="text-xs mt-0.5">主題</span>
-            </button>
-        </div>
-    </nav>
-
-    <!-- Toast -->
-    <div id="toast" class="fixed bottom-24 md:bottom-8 left-1/2 -translate-x-1/2 bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 px-4 py-2 rounded-lg shadow-lg transform transition-all duration-300 opacity-0 translate-y-4 pointer-events-none z-[60]" role="alert">
-        <span id="toast-message"></span>
-    </div>
-
     <script>
-        // Theme Toggle
-        function toggleTheme() {
-            const isDark = document.documentElement.classList.toggle('dark');
-            localStorage.setItem('theme', isDark ? 'dark' : 'light');
-        }
-        document.getElementById('theme-toggle-desktop')?.addEventListener('click', toggleTheme);
-        document.getElementById('theme-toggle-mobile')?.addEventListener('click', toggleTheme);
-
-        // Toast
-        function showToast(message, duration = 2000) {
-            const toast = document.getElementById('toast');
-            document.getElementById('toast-message').textContent = message;
-            toast.classList.remove('opacity-0', 'translate-y-4', 'pointer-events-none');
-            toast.classList.add('opacity-100', 'translate-y-0');
-            setTimeout(() => {
-                toast.classList.add('opacity-0', 'translate-y-4', 'pointer-events-none');
-                toast.classList.remove('opacity-100', 'translate-y-0');
-            }, duration);
-        }
+        // Initialize shared components
+        FeiFeiTools.init({ currentPage: '演講時間計算機', currentCategory: 'text' });
+        const showToast = FeiFeiTools.showToast;
 
         // State
         let currentSpeed = 170;
@@ -453,8 +382,8 @@ TechFlow 用 AI 驅動的知識圖譜技術，讓企業資訊的存取速度提�
         function countWords(text) {
             if (!text.trim()) return 0;
             const chinese = (text.match(/[一-鿿㐀-䶿]/g) || []).length;
-            const english = (text.match(/\b[a-zA-Z]+\b/g) || []).length;
-            return chinese + english;
+            const englishAndNumbers = (text.match(/\b[a-zA-Z0-9]+(?:'[a-zA-Z]+)?\b/g) || []).length;
+            return chinese + englishAndNumbers;
         }
 
         // Get sections (split by double newline or paragraph)
@@ -565,21 +494,9 @@ TechFlow 用 AI 驅動的知識圖譜技術，讓企業資訊的存取速度提�
         async function copyResult() {
             const words = document.getElementById('live-words').textContent;
             const buffer = document.getElementById('live-buffer').textContent;
-            const result = `演講時間估算結果
-================
-總字數：${words}
-暫停緩衝：${buffer}
-基礎時間：${document.getElementById('result-base').textContent}
-慢速 (110 wpm)：${document.getElementById('result-slow').textContent}
-正常 (140 wpm)：${document.getElementById('result-normal').textContent}
-快速 (170 wpm)：${document.getElementById('result-fast').textContent}`;
+            const result = `演講時間估算結果\n================\n總字數：${words}\n暫停緩衝：${buffer}\n基礎時間：${document.getElementById('result-base').textContent}\n慢速 (110 wpm)：${document.getElementById('result-slow').textContent}\n正常 (140 wpm)：${document.getElementById('result-normal').textContent}\n快速 (170 wpm)：${document.getElementById('result-fast').textContent}`;
 
-            try {
-                await navigator.clipboard.writeText(result);
-                showToast('已複製到剪貼簿');
-            } catch (err) {
-                showToast('複製失敗');
-            }
+            await FeiFeiTools.copyToClipboard(result);
         }
 
         // Initialize


### PR DESCRIPTION
## Summary
Added a new Speech Timer tool that helps users estimate the duration of presentations, speeches, and pitches based on word count and speaking speed.

## Key Changes
- **New tool**: `speech-timer.html` - A comprehensive speech duration calculator with the following features:
  - Text input with automatic word counting (supports Chinese and English)
  - Manual word count input option
  - Three speaking speed presets (110, 140, 170 WPM)
  - Adjustable pause buffer (0-30%)
  - Real-time preview of estimated duration
  - Speed comparison showing slow/normal/fast estimates
  - Per-section timing breakdown for multi-paragraph content
  - Example templates (keynote, classroom, pitch)
  - Copy-to-clipboard functionality for results
  - Full dark mode support
  - Mobile-responsive design with touch-friendly controls

- **Updated navigation**: 
  - Added speech-timer to the tools catalog in `components/shared.js`
  - Updated table of contents script in `.github/scripts/update_toc.py`

## Implementation Details
- Built with Tailwind CSS for styling and responsive layout
- Includes comprehensive SEO metadata and Open Graph tags
- Implements proper accessibility features (ARIA labels, skip links, semantic HTML)
- Uses vanilla JavaScript for calculations and UI interactions
- Supports both Chinese and English word counting with regex patterns
- Provides cumulative timing for multi-section presentations
- Toast notifications for user feedback
- Theme toggle functionality (light/dark mode with localStorage persistence)

https://claude.ai/code/session_019zp8h7ejkCS8VcMsLGuqCF