### PR TITLE
修正演講時間計算機 showToast 重複宣告錯誤

### DIFF
--- a/speech-timer.html
+++ b/speech-timer.html
@@ -290,7 +290,6 @@
     <script>
         // Initialize shared components
         FeiFeiTools.init({ currentPage: '演講時間計算機', currentCategory: 'text' });
-        const showToast = FeiFeiTools.showToast;
 
         // State
         let currentSpeed = 170;
@@ -329,7 +328,7 @@ TechFlow 用 AI 驅動的知識圖譜技術，讓企業資訊的存取速度提�
             if (currentTab !== 'text') switchTab('text');
             document.getElementById('text-input').value = EXAMPLES[key];
             calculate();
-            showToast('已載入範例');
+            FeiFeiTools.showToast('已載入範例');
         }
 
         // Tab switching
@@ -488,7 +487,7 @@ TechFlow 用 AI 驅動的知識圖譜技術，讓企業資訊的存取速度提�
             document.getElementById('buffer-range').value = 10;
             updateBuffer();
             calculate();
-            showToast('已清除');
+            FeiFeiTools.showToast('已清除');
         }
 
         async function copyResult() {


### PR DESCRIPTION
## Summary

- `shared.js` 已在全域定義 `showToast`，`const showToast = FeiFeiTools.showToast` 造成重複宣告，導致整個 script 崩潰\n- 移除 `const showToast` 重複宣告，改用 `FeiFeiTools.showToast()` 直接呼叫\n\n## 修正的錯誤\n\n- `Uncaught SyntaxError: Identifier 'showToast' has already been declared`\n- `Uncaught ReferenceError: calculate is not defined`（連帶影響）\n- `Uncaught ReferenceError: loadExample is not defined`（連帶影響）\n- `Uncaught ReferenceError: switchTab is not defined`（連帶影響）

---
_Generated by [Claude Code](https://claude.ai/code/session_019zp8h7ejkCS8VcMsLGuqCF)_